### PR TITLE
Add GitHub actions workflows for unit testing, checking formatting, and updating actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,40 @@
+name: Build and test
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        buildtype: [debug, release]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update apt repositories for ccache
+        run: sudo apt update
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ccache-linux-${{ matrix.buildtype }}
+      - name: Setup compiler and build tools
+        run: sudo apt install --no-install-recommends --yes g++-12 meson ninja-build
+      - name: Configure
+        run: |
+            CXX="ccache g++-12" meson setup \
+              --buildtype ${{ matrix.buildtype }} \
+              --warnlevel 3 \
+              --werror \
+              -Dcatch2:werror=false \
+              -Dcli11:werror=false \
+              -Dfmt:werror=false \
+              -Dnlohmann_json:werror=false \
+              -Dsqlite3:werror=false \
+              build .
+      - name: Build
+        run: ninja -C build
+      - name: Test
+        run: ./build/unit

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,11 +28,6 @@ jobs:
               --buildtype ${{ matrix.buildtype }} \
               --warnlevel 3 \
               --werror \
-              -Dcatch2:werror=false \
-              -Dcli11:werror=false \
-              -Dfmt:werror=false \
-              -Dnlohmann_json:werror=false \
-              -Dsqlite3:werror=false \
               build .
       - name: Build
         run: ninja -C build

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -14,4 +14,4 @@ jobs:
     - name: Check formatting
       uses: jidicula/clang-format-action@v4.13.0
       with:
-        clang-format-version: '14' # TODO?
+        clang-format-version: '18'

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,0 +1,17 @@
+name: clang-format
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  formatting-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check formatting
+      uses: jidicula/clang-format-action@v4.13.0
+      with:
+        clang-format-version: '14' # TODO?

--- a/meson.build
+++ b/meson.build
@@ -15,11 +15,11 @@ conf_data = configuration_data()
 #
 # use meson wrap to provide the dependencies, because the 'default_library=static' option
 # will be propogated to each dependency, for a statically linked executable.
-catch_dep = subproject('catch2').get_variable('catch2_with_main_dep')
-cli11_dep = subproject('cli11').get_variable('CLI11_dep')
-fmt_dep   = subproject('fmt').get_variable('fmt_dep')
-json_dep = subproject('nlohmann_json').get_variable('nlohmann_json_dep')
-sqlite3_dep = subproject('sqlite3').get_variable('sqlite3_dep')
+catch_dep = subproject('catch2', default_options: 'werror=false').get_variable('catch2_with_main_dep')
+cli11_dep = subproject('cli11', default_options: 'werror=false').get_variable('CLI11_dep')
+fmt_dep   = subproject('fmt', default_options: 'werror=false').get_variable('fmt_dep')
+json_dep = subproject('nlohmann_json', default_options: 'werror=false').get_variable('nlohmann_json_dep')
+sqlite3_dep = subproject('sqlite3', default_options: 'werror=false').get_variable('sqlite3_dep')
 
 # the lib dependency is all of the common funtionality shared between the CLI
 # and the slurm plugin.

--- a/src/cli/start.cpp
+++ b/src/cli/start.cpp
@@ -22,7 +22,8 @@ void start_help() {
     fmt::println("start help");
 }
 
-void start_args::add_cli(CLI::App& cli, [[maybe_unused]] global_settings& settings) {
+void start_args::add_cli(CLI::App& cli,
+                         [[maybe_unused]] global_settings& settings) {
     auto* start_cli = cli.add_subcommand("start", "start a uenv session");
     start_cli->add_option("-v,--view", view_description,
                           "comma separated list of views to load");
@@ -33,7 +34,8 @@ void start_args::add_cli(CLI::App& cli, [[maybe_unused]] global_settings& settin
     start_cli->callback([&settings]() { settings.mode = uenv::mode_start; });
 }
 
-int start(const start_args& args, [[maybe_unused]] const global_settings& globals) {
+int start(const start_args& args,
+          [[maybe_unused]] const global_settings& globals) {
     fmt::println("running start with options {}", args);
     const auto env =
         concretise_env(args.uenv_description, args.view_description);

--- a/src/cli/start.cpp
+++ b/src/cli/start.cpp
@@ -22,7 +22,7 @@ void start_help() {
     fmt::println("start help");
 }
 
-void start_args::add_cli(CLI::App& cli, global_settings& settings) {
+void start_args::add_cli(CLI::App& cli, [[maybe_unused]] global_settings& settings) {
     auto* start_cli = cli.add_subcommand("start", "start a uenv session");
     start_cli->add_option("-v,--view", view_description,
                           "comma separated list of views to load");
@@ -33,7 +33,7 @@ void start_args::add_cli(CLI::App& cli, global_settings& settings) {
     start_cli->callback([&settings]() { settings.mode = uenv::mode_start; });
 }
 
-int start(const start_args& args, const global_settings& globals) {
+int start(const start_args& args, [[maybe_unused]] const global_settings& globals) {
     fmt::println("running start with options {}", args);
     const auto env =
         concretise_env(args.uenv_description, args.view_description);

--- a/src/uenv/lex.cpp
+++ b/src/uenv/lex.cpp
@@ -110,9 +110,12 @@ class lexer_impl {
                 ++stream_;
                 return;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
             case 'a' ... 'z':
             case 'A' ... 'Z':
             case '0' ... '9':
+#pragma GCC diagnostic pop
             case '_':
                 token_ = symbol();
                 return;

--- a/src/util/expected.h
+++ b/src/util/expected.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// clang-format off
+
 // Taken from https://github.com/eth-cscs/arbor, https://arbor-sim.org/
 /*
 Copyright 2016-2020 Eidgenössische Technische Hochschule Zürich and

--- a/test/unit/envvars.cpp
+++ b/test/unit/envvars.cpp
@@ -93,7 +93,8 @@ TEST_CASE("envvarset get final values", "[envvars]") {
     ev.update_prefix_path("C", {uenv::update_kind::append, {"c", "d"}});
 
     {
-        auto getenv = [](const std::string& name) -> const char* {
+        auto getenv =
+            []([[maybe_unused]] const std::string& name) -> const char* {
             return nullptr;
         };
         REQUIRE_THAT(ev.get_values(getenv),


### PR DESCRIPTION
- Adds a workflow that builds and runs the unit test in debug and release mode. It enables warnings and `-Werror` for uenv itself.
- Adds a workflow that checks formatting with clang-format.
- Adds a dependabot workflow that checks for actions updates daily.