### PR TITLE
Run tests with address, undefined, and thread sanitizer in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,11 @@ jobs:
     strategy:
       matrix:
         buildtype: [debug, release]
-        sanitizer: [none, leak, undefined, thread]
+        sanitizer: [none, address, leak, undefined, thread]
+        exclude:
+          # False positive warnings in release builds: https://godbolt.org/z/vT3nqGxzW
+          - buildtype: release
+            sanitizer: address
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,4 +42,7 @@ jobs:
       - name: Setup Test
         run: cd test/setup && ./setup
       - name: Test
-        run: cd build && ./unit
+        run: |
+          export ASAN_OPTIONS=fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
+          export UBSAN_OPTIONS=print_stacktrace=1
+          cd build && ./unit

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         buildtype: [debug, release]
+        sanitizer: [none, leak, undefined, thread]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -21,13 +22,14 @@ jobs:
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ccache-linux-${{ matrix.buildtype }}
+          key: ccache-linux-${{ matrix.buildtype }}-${{ matrix.sanitizer }}
       - name: Setup compiler and build tools
         run: sudo apt install --no-install-recommends --yes g++-12 meson ninja-build
       - name: Configure
         run: |
             CXX="ccache g++-12" meson setup \
               --buildtype ${{ matrix.buildtype }} \
+              -Db_sanitize=${{ matrix.sanitizer }} \
               --warnlevel 3 \
               --werror \
               build .


### PR DESCRIPTION
tsan is maybe a bit unnecessary, but doesn't hurt much, and then it's there in case there will be threading in the future.

msan is not supported by GCC so leaving that out (I believe that also requires recompiling the standard library to be effective).

asan reports false positives during release mode compilation so I've kept asan in debug builds only, and added lsan for release and debug.