### PR TITLE
support for files without external meta data

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,10 +37,11 @@ lib_src = [
         'src/uenv/meta.cpp',
         'src/uenv/parse.cpp',
         'src/uenv/repository.cpp',
+        'src/uenv/uenv.cpp',
+        'src/util/fs.cpp',
         'src/util/shell.cpp',
         'src/util/strings.cpp',
         'src/util/subprocess.cpp',
-        'src/uenv/uenv.cpp',
 ]
 lib_inc = include_directories('src')
 
@@ -76,6 +77,7 @@ endif
 unit_src = [
         'test/unit/env.cpp',
         'test/unit/envvars.cpp',
+        'test/unit/fs.cpp',
         'test/unit/lex.cpp',
         'test/unit/main.cpp',
         'test/unit/parse.cpp',

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -31,8 +31,15 @@ meta_info find_meta_path(const std::filesystem::path& sqfs_path) {
     meta_info meta;
     if (fs::is_directory(sqfs_path.parent_path() / "meta")) {
         meta.path = sqfs_path.parent_path() / "meta";
+        spdlog::debug("find_meta_path: {} found external meta path {}",
+                      sqfs_path.string(), meta.path->string());
     } else if (auto p = util::unsquashfs_tmp(sqfs_path, "meta")) {
-        meta.path = *p;
+        meta.path = *p / "meta";
+        spdlog::debug("find_meta_path: {} found internal meta path {}",
+                      sqfs_path.string(), meta.path->string());
+    } else {
+        spdlog::debug("find_meta_path: {} no meta path found",
+                      sqfs_path.string());
     }
 
     if (meta.path) {
@@ -40,6 +47,10 @@ meta_info find_meta_path(const std::filesystem::path& sqfs_path) {
 
         if (fs::is_regular_file(env_meta)) {
             meta.env = env_meta;
+            spdlog::debug("find_meta_path: {} found env meta {}",
+                          sqfs_path.string(), meta.env->string());
+        } else {
+            spdlog::debug("find_meta_path: {} no env meta", sqfs_path.string());
         }
     }
 

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -13,10 +13,38 @@
 #include <uenv/meta.h>
 #include <uenv/parse.h>
 #include <uenv/repository.h>
+#include <util/subprocess.h>
 
 namespace uenv {
 
 using util::unexpected;
+
+std::filesystem::path meta_path(const std::filesystem::path& sqfs_path) {
+    namespace fs = std::filesystem;
+
+    // set the meta data path and env.json path if they exist
+    auto meta_p = sqfs_path.parent_path() / "meta";
+    auto env_meta_p = meta_p / "env.json";
+
+    // the meta path exists - use it
+    if (fs::is_directory(meta_p)) {
+        return meta_p;
+    }
+
+    // open the image
+
+    auto p = util::run({
+        "unsquashfs",
+        sqfs_path.string(),
+    });
+
+    /*
+    std::optional<fs::path> meta_path =
+        fs::is_directory(meta_p) ? meta_p : std::optional<fs::path>{};
+    */
+
+    return {};
+}
 
 util::expected<env, std::string>
 concretise_env(const std::string& uenv_args,

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -25,12 +25,17 @@ struct temp_dir_wrap {
     }
 };
 
-std::filesystem::path make_temp_dir() {
-    // persistant storage for the temporary paths that will delete the paths on
-    // exit. This makes temporary paths persistent for the duration of the
-    // application's execution.
-    static std::vector<temp_dir_wrap> cache;
+// persistant storage for the temporary paths that will delete the paths on
+// exit. This makes temporary paths persistent for the duration of the
+// application's execution.
+static std::vector<temp_dir_wrap> tmp_dir_cache;
 
+void clear_temp_dirs() {
+    tmp_dir_cache.clear();
+    spdlog::debug("clear_temp_dir: deleted all temp files");
+}
+
+std::filesystem::path make_temp_dir() {
     namespace fs = std::filesystem;
     auto tmp_template =
         fs::temp_directory_path().string() + "/uenv-XXXXXXXXXXXX";
@@ -42,7 +47,7 @@ std::filesystem::path make_temp_dir() {
     spdlog::debug("make_temp_dir: created {}", tmp_path.string(),
                   fs::is_directory(tmp_path));
 
-    cache.emplace_back(tmp_path);
+    tmp_dir_cache.emplace_back(tmp_path);
 
     return tmp_path;
 }

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -30,9 +30,14 @@ struct temp_dir_wrap {
 // persistant storage for the temporary paths that will delete the paths on
 // exit. This makes temporary paths persistent for the duration of the
 // application's execution.
-// Use a dequeu because it will not copy/move/delete its contents as it grows.
+// Use a deque because it will not copy/move/delete its contents as it grows.
 static std::deque<temp_dir_wrap> tmp_dir_cache;
 
+// the temp paths are deleted automatically when tmp_dir_cache is cleaned up
+// at the end of execution, except when execvp is used to replace the current
+// process.
+// use this function to force early clean up in such situations, so that no
+// tmp paths remain after execution.
 void clear_temp_dirs() {
     tmp_dir_cache.clear();
 }
@@ -57,7 +62,6 @@ std::filesystem::path make_temp_dir() {
 util::expected<std::filesystem::path, std::string>
 unsquashfs_tmp(const std::filesystem::path& sqfs,
                const std::filesystem::path& contents) {
-
     namespace fs = std::filesystem;
 
     if (!fs::is_regular_file(sqfs)) {

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -1,0 +1,98 @@
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+#include <spdlog/spdlog.h>
+
+#include "expected.h"
+#include "fs.h"
+#include "subprocess.h"
+
+namespace util {
+
+temp_dir::~temp_dir() {
+    std::error_code ec;
+
+    if (std::filesystem::is_directory(path_)) {
+        // ignore the error code - being unable to delete a temp path is not the
+        // end of the world.
+        auto n = std::filesystem::remove_all(path_, ec);
+        spdlog::debug("temp_dir: deleted {} files in {}", n, path_.string());
+    }
+
+    // path_ is either set, or default constructed as
+    //   std::filesystem::path::empty
+    //   https://en.cppreference.com/w/cpp/filesystem/path/empty deleting an
+    //   empty
+    // path is safe - it is a noop.
+}
+
+temp_dir::temp_dir(temp_dir&& p) : path_(std::move(p.path_)) {
+}
+
+temp_dir::temp_dir(std::filesystem::path p) : path_(std::move(p)) {
+}
+
+const std::filesystem::path& temp_dir::path() const {
+    return path_;
+}
+
+temp_dir make_temp_dir() {
+    namespace fs = std::filesystem;
+    auto tmp_template =
+        fs::temp_directory_path().string() + "/uenv-XXXXXXXXXXXX";
+    std::vector<char> base(tmp_template.data(),
+                           tmp_template.data() + tmp_template.size() + 1);
+
+    fs::path tmp_path = mkdtemp(base.data());
+
+    spdlog::debug("make_temp_dir: created {}", tmp_path.string(),
+                  fs::is_directory(tmp_path));
+
+    return tmp_path;
+}
+
+util::expected<temp_dir, std::string>
+unsquashfs_tmp(const std::filesystem::path& sqfs,
+               const std::filesystem::path& contents) {
+
+    namespace fs = std::filesystem;
+
+    if (!fs::is_regular_file(sqfs)) {
+        return unexpected(fmt::format("unsquashfs_tmp: {} file does not exist",
+                                      sqfs.string()));
+    }
+
+    auto base = make_temp_dir();
+    std::vector<std::string> command{"unsquashfs",  "-no-exit",
+                                     "-d",          base.path().string(),
+                                     sqfs.string(), contents.string()};
+    spdlog::debug("unsquashfs_tmp: attempting to unpack {} from {}",
+                  contents.string(), sqfs.string());
+
+    auto proc = run(command);
+
+    if (!proc) {
+        return unexpected(fmt::format(
+            "unsquashfs_tmp: unable to run unsquashfs: {}", proc.error()));
+    }
+
+    auto status = proc->wait();
+
+    spdlog::debug("unsquashfs_tmp: command '{}' retured status {}",
+                  fmt::join(command, " "), status);
+
+    if (status != 0) {
+        spdlog::warn("unsquashfs_tmp: unable to extract {} from {}",
+                     contents.string(), sqfs.string());
+        return unexpected(
+            fmt::format("unsquashfs_tmp: unable to extract {} from {}",
+                        contents.string(), sqfs.string()));
+    }
+
+    spdlog::info("unsquashfs_tmp: data unpacked to {}", base.path().string());
+    return base;
+}
+} // namespace util

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -13,4 +13,6 @@ util::expected<std::filesystem::path, std::string>
 unsquashfs_tmp(const std::filesystem::path& sqfs,
                const std::filesystem::path& contents);
 
+void clear_temp_dirs();
+
 } // namespace util

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include <util/expected.h>
+
+namespace util {
+
+class temp_dir {
+    std::filesystem::path path_{};
+
+  public:
+    temp_dir() = delete;
+    temp_dir(const temp_dir&) = delete;
+
+    temp_dir(temp_dir&& p);
+    temp_dir(std::filesystem::path p);
+
+    const std::filesystem::path& path() const;
+
+    ~temp_dir();
+};
+
+temp_dir make_temp_dir();
+
+util::expected<temp_dir, std::string>
+unsquashfs_tmp(const std::filesystem::path& sqfs,
+               const std::filesystem::path& contents);
+
+} // namespace util

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -7,24 +7,9 @@
 
 namespace util {
 
-class temp_dir {
-    std::filesystem::path path_{};
+std::filesystem::path make_temp_dir();
 
-  public:
-    temp_dir() = delete;
-    temp_dir(const temp_dir&) = delete;
-
-    temp_dir(temp_dir&& p);
-    temp_dir(std::filesystem::path p);
-
-    const std::filesystem::path& path() const;
-
-    ~temp_dir();
-};
-
-temp_dir make_temp_dir();
-
-util::expected<temp_dir, std::string>
+util::expected<std::filesystem::path, std::string>
 unsquashfs_tmp(const std::filesystem::path& sqfs,
                const std::filesystem::path& contents);
 

--- a/src/util/shell.cpp
+++ b/src/util/shell.cpp
@@ -10,6 +10,7 @@
 #include <spdlog/spdlog.h>
 
 #include <util/expected.h>
+#include <util/fs.h>
 
 namespace util {
 
@@ -36,6 +37,11 @@ util::expected<std::filesystem::path, std::string> current_shell() {
 
 int exec(const std::vector<std::string>& args) {
     std::vector<char*> argv;
+
+    // clean up temporary files before calling execve, because the descructor
+    // that manages their deletion will not be deleted after the current process
+    // has been replaced.
+    util::clear_temp_dirs();
 
     // unsafe {
     for (auto& arg : args) {

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -154,3 +154,37 @@ function teardown() {
     assert_failure
     assert_line --partial "Permission denied"
 }
+
+@test "run" {
+    export UENV_REPO_PATH=$REPOS/apptool
+
+    #
+    # check that run looks up images in the repo and mounts at the correct location
+    #
+    run uenv run tool -- ls /user-tools
+    assert_success
+    assert_output --regexp "meta"
+
+    run uenv run app/42.0:v1 -- ls /user-environment
+    assert_success
+    assert_output --regexp "meta"
+
+    #
+    # check --view
+    #
+    run uenv run --view=tool tool -- tool
+    assert_success
+    assert_output "hello tool"
+
+    run uenv run --view=app app/42.0:v1 -- app
+    assert_success
+    assert_output "hello app"
+
+    #
+    # check --view works when reading meta data from inside a standalone sqfs file
+    #
+
+    run uenv run --view=tool $SQFS_LIB/apptool/standalone/tool.squashfs -- tool
+    assert_success
+    assert_output "hello tool"
+}

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -11,7 +11,7 @@ function setup() {
 
     export SRC_PATH=$(realpath ../../)
 
-    export PATH="$(realpath ../../install/bin):$PATH"
+    export PATH="$(realpath ../../build):$PATH"
 
     unset UENV_MOUNT_LIST
 

--- a/test/setup/setup_repos.bash
+++ b/test/setup/setup_repos.bash
@@ -39,6 +39,11 @@ function setup_repo_apptool() {
             cp ${sqfs} $img_path/store.squashfs
             cp -R ${sources}/${name}/meta $img_path
         done
+
+        img_path="$sqfs_path/standalone"
+        mkdir -p $img_path
+        cp ${sqfs} $img_path/${name}.squashfs
+
         rm ${sqfs}
 
         sed -i "s|{${name}-sha}|${sha}|g" schema.sql

--- a/test/unit/fs.cpp
+++ b/test/unit/fs.cpp
@@ -10,9 +10,9 @@ namespace fs = std::filesystem;
 
 TEST_CASE("make_temp_dir", "[fs]") {
     auto dir1 = util::make_temp_dir();
-    REQUIRE(fs::is_directory(dir1.path()));
+    REQUIRE(fs::is_directory(dir1));
     auto dir2 = util::make_temp_dir();
-    REQUIRE(dir1.path() != dir2.path());
+    REQUIRE(dir1 != dir2);
     fmt::println("end-of-funtion");
 }
 
@@ -25,15 +25,14 @@ TEST_CASE("unsquashfs", "[fs]") {
         auto meta = util::unsquashfs_tmp(sqfs, "meta");
         fmt::println("returned from unsquashfs");
         REQUIRE(meta);
-        REQUIRE(fs::is_directory(meta->path()));
-        REQUIRE(fs::is_directory(meta->path() / "meta"));
+        REQUIRE(fs::is_directory(*meta));
+        REQUIRE(fs::is_directory(*meta / "meta"));
     }
     {
-        std::vector<util::temp_dir> buffer;
         const int nbuf = 5;
         {
             for (int i = 0; i < nbuf; ++i) {
-                buffer.push_back(*util::unsquashfs_tmp(sqfs, "meta/env.json"));
+                auto x = util::unsquashfs_tmp(sqfs, "meta/env.json");
             }
         }
     }

--- a/test/unit/fs.cpp
+++ b/test/unit/fs.cpp
@@ -1,0 +1,40 @@
+#include <filesystem>
+
+#include <catch2/catch_all.hpp>
+#include <fmt/core.h>
+
+#include <util/fs.h>
+#include <util/subprocess.h>
+
+namespace fs = std::filesystem;
+
+TEST_CASE("make_temp_dir", "[fs]") {
+    auto dir1 = util::make_temp_dir();
+    REQUIRE(fs::is_directory(dir1.path()));
+    auto dir2 = util::make_temp_dir();
+    REQUIRE(dir1.path() != dir2.path());
+    fmt::println("end-of-funtion");
+}
+
+TEST_CASE("unsquashfs", "[fs]") {
+    std::string sqfs =
+        "/home/bcumming/software/uenv2/test/scratch/repos/apptool/images/"
+        "0343a5636e6d59ed8e5f7fcc35c34719597ff024be0ce796cc0532804b3aeefa/"
+        "store.squashfs";
+    {
+        auto meta = util::unsquashfs_tmp(sqfs, "meta");
+        fmt::println("returned from unsquashfs");
+        REQUIRE(meta);
+        REQUIRE(fs::is_directory(meta->path()));
+        REQUIRE(fs::is_directory(meta->path() / "meta"));
+    }
+    {
+        std::vector<util::temp_dir> buffer;
+        const int nbuf = 5;
+        {
+            for (int i = 0; i < nbuf; ++i) {
+                buffer.push_back(*util::unsquashfs_tmp(sqfs, "meta/env.json"));
+            }
+        }
+    }
+}

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -1,3 +1,5 @@
+#include <charconv>
+
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch_all.hpp>
 

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -5,6 +5,34 @@
 
 static struct unit_init_log {
     unit_init_log() {
-        uenv::init_log(spdlog::level::trace, spdlog::level::off);
+        // use warn as the default log level
+        auto log_level = spdlog::level::warn;
+        bool invalid_env = false;
+
+        // check the environment variable UENV_LOG_LEVEL
+        auto log_level_str = std::getenv("UENV_LOG_LEVEL");
+        if (log_level_str != nullptr) {
+            int lvl;
+            auto [ptr, ec] = std::from_chars(
+                log_level_str, log_level_str + std::strlen(log_level_str), lvl);
+
+            if (ec == std::errc()) {
+                if (lvl == 1) {
+                    log_level = spdlog::level::info;
+                } else if (lvl == 2) {
+                    log_level = spdlog::level::debug;
+                } else if (lvl > 2) {
+                    log_level = spdlog::level::trace;
+                }
+            } else {
+                invalid_env = true;
+            }
+        }
+        uenv::init_log(log_level, spdlog::level::info);
+        if (invalid_env) {
+            spdlog::warn(fmt::format("UENV_LOG_LEVEL invalid value '{}' -- "
+                                     "expected a value between 0 and 3",
+                                     log_level_str));
+        }
     }
 } uil{};

--- a/test/unit/repository.cpp
+++ b/test/unit/repository.cpp
@@ -16,7 +16,6 @@ TEST_CASE("read-only", "[repository]") {
         SKIP(fmt::format("{}", store.error()));
     }
 
-    fmt::println("db path: {}", store->db_path().string());
     {
         auto results = store->query({{}, {}, {}, {}, {}});
         if (!results) {
@@ -29,7 +28,6 @@ TEST_CASE("read-only", "[repository]") {
         //}
     }
 
-    fmt::println("");
     {
         auto results = store->query({"mch", {}, {}, {}, {}});
         if (!results) {
@@ -42,7 +40,6 @@ TEST_CASE("read-only", "[repository]") {
         //}
     }
 
-    fmt::println("");
     {
         auto results = store->query({{}, "v7", {}, {}, {}});
         if (!results) {
@@ -55,7 +52,6 @@ TEST_CASE("read-only", "[repository]") {
         //}
     }
 
-    fmt::println("");
     {
         auto results = store->query({{}, "24.7", "v1-rc1", {}, "a100"});
         if (!results) {
@@ -68,7 +64,6 @@ TEST_CASE("read-only", "[repository]") {
         //}
     }
 
-    fmt::println("");
     {
         auto results = store->query({"wombat", {}, {}, {}, {}});
         if (!results) {


### PR DESCRIPTION
Add support for reading the meta data inside a squashfs image.

Calls the external `unsquashfs` application to unpack the `meta` path inside a squashfs image to a temporary working directory.