### PR TITLE
improve support for namespaces

### DIFF
--- a/src/cli/find.cpp
+++ b/src/cli/find.cpp
@@ -30,6 +30,8 @@ void image_find_args::add_cli(CLI::App& cli,
     find_cli->add_option("uenv", uenv_description, "search term");
     find_cli->add_flag("--no-header", no_header,
                        "print only the matching records, with no header.");
+    find_cli->add_flag("--build", build,
+                       "invalid: replaced with 'build::' prefix on uenv label");
     find_cli->callback(
         [&settings]() { settings.mode = uenv::cli_mode::image_find; });
 
@@ -38,6 +40,15 @@ void image_find_args::add_cli(CLI::App& cli,
 
 int image_find([[maybe_unused]] const image_find_args& args,
                [[maybe_unused]] const global_settings& settings) {
+    if (args.build) {
+        std::string descr = args.uenv_description.value_or("");
+        term::error(
+            "the --build flag has been removed.\nSpecify the build namespace "
+            "as part of the uenv description, e.g.\n{}",
+            color::yellow(fmt::format("uenv image find build::{}", descr)));
+        return 1;
+    }
+
     // find the search term that was provided by the user
     uenv_label label{};
     std::string nspace{site::default_namespace()};

--- a/src/cli/find.h
+++ b/src/cli/find.h
@@ -15,7 +15,6 @@ namespace uenv {
 struct image_find_args {
     std::optional<std::string> uenv_description;
     bool no_header = false;
-    std::string nspace = "deploy";
     void add_cli(CLI::App&, global_settings& settings);
 };
 

--- a/src/cli/find.h
+++ b/src/cli/find.h
@@ -15,6 +15,7 @@ namespace uenv {
 struct image_find_args {
     std::optional<std::string> uenv_description;
     bool no_header = false;
+    bool build = false;
     void add_cli(CLI::App&, global_settings& settings);
 };
 

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -39,6 +39,8 @@ void image_pull_args::add_cli(CLI::App& cli,
     pull_cli->add_flag("--only-meta", only_meta, "only download meta data");
     pull_cli->add_flag("--force", force,
                        "download and overwrite existing images");
+    pull_cli->add_flag("--build", build,
+                       "invalid: replaced with 'build::' prefix on uenv label");
     pull_cli->callback(
         [&settings]() { settings.mode = uenv::cli_mode::image_pull; });
 
@@ -47,10 +49,16 @@ void image_pull_args::add_cli(CLI::App& cli,
 
 int image_pull([[maybe_unused]] const image_pull_args& args,
                [[maybe_unused]] const global_settings& settings) {
-
     namespace fs = std::filesystem;
 
-    spdlog::info("image pull: {}", args);
+    if (args.build) {
+        term::error(
+            "the --build flag has been removed.\nSpecify the build namespace "
+            "as part of the uenv description, e.g.\n{}",
+            color::yellow(fmt::format("uenv image pull build::{}",
+                                      args.uenv_description)));
+        return 1;
+    }
 
     // pull the search term that was provided by the user
     uenv_label label{};

--- a/src/cli/pull.h
+++ b/src/cli/pull.h
@@ -16,7 +16,6 @@ struct image_pull_args {
     std::string uenv_description;
     bool only_meta = false;
     bool force = false;
-    std::string nspace = "deploy";
     void add_cli(CLI::App&, global_settings& settings);
 };
 
@@ -35,7 +34,7 @@ template <> class fmt::formatter<uenv::image_pull_args> {
     constexpr auto format(uenv::image_pull_args const& opts,
                           FmtContext& ctx) const {
         return fmt::format_to(
-            ctx.out(), "(image pull {} .only_meta={} .force={} .namespace={})",
-            opts.uenv_description, opts.only_meta, opts.force, opts.nspace);
+            ctx.out(), "(image pull {} .only_meta={} .force={})",
+            opts.uenv_description, opts.only_meta, opts.force);
     }
 };

--- a/src/cli/pull.h
+++ b/src/cli/pull.h
@@ -16,6 +16,7 @@ struct image_pull_args {
     std::string uenv_description;
     bool only_meta = false;
     bool force = false;
+    bool build = false;
     void add_cli(CLI::App&, global_settings& settings);
 };
 

--- a/src/site/site.h
+++ b/src/site/site.h
@@ -12,6 +12,9 @@ namespace site {
 // on CSCS systems this is derived from the CLUSTER_NAME environment variable
 std::optional<std::string> get_system_name(std::optional<std::string>);
 
+// default namespace for image deployment
+std::string default_namespace();
+
 util::expected<uenv::repository, std::string>
 registry_listing(const std::string& nspace);
 

--- a/src/uenv/parse.h
+++ b/src/uenv/parse.h
@@ -61,6 +61,10 @@ util::expected<std::string, parse_error> parse_path(const std::string& in);
 
 util::expected<uenv_label, parse_error> parse_uenv_label(const std::string& in);
 
+// pares a namespacesd uenv label
+util::expected<uenv_nslabel, parse_error>
+parse_uenv_nslabel(const std::string& in);
+
 util::expected<uenv_registry_entry, parse_error>
 parse_registry_entry(const std::string& in);
 

--- a/src/uenv/repository.cpp
+++ b/src/uenv/repository.cpp
@@ -755,11 +755,9 @@ repository_impl::query(const uenv_label& label) const {
         results.push_back(record_from_query(*s).value());
     }
 
-    spdlog::info("will we checking for id and sha");
     // now check for id and sha search terms
     if (label.only_name()) {
         query_terms.erase(query_terms.begin());
-        spdlog::info("checking for id and sha");
         // search for an if name could also be an id
         if (is_sha(*label.name, 16)) {
             query_terms.push_back(

--- a/src/uenv/uenv.h
+++ b/src/uenv/uenv.h
@@ -29,6 +29,14 @@ struct uenv_label {
     bool partially_qualified() const {
         return name && version && tag;
     }
+    bool empty() const {
+        return !fully_qualified();
+    }
+};
+
+struct uenv_nslabel {
+    std::optional<std::string> nspace;
+    uenv_label label;
 };
 
 struct uenv_date {


### PR DESCRIPTION
remove the `-nspace` flag that replaced `--build`:

* now the namespace is part of the uenv label, e.g. `build::prgenv-gnu`
* add a helpful error message if the old `--build` flag is used
* use the namespace correctly when searching for uenv in the registry - now the `service` namespace used by the build service can be accessed