### PR TITLE
uenv build: remove timeout in curl::upload

### DIFF
--- a/src/util/curl.cpp
+++ b/src/util/curl.cpp
@@ -124,7 +124,6 @@ expected<std::string, error> upload(std::string url,
     CURL_EASY(curl_easy_setopt(h, CURLOPT_USE_SSL, CURLUSESSL_ALL));
 
     CURL_EASY(curl_easy_setopt(h, CURLOPT_CONNECTTIMEOUT_MS, 5000L));
-    CURL_EASY(curl_easy_setopt(h, CURLOPT_TIMEOUT_MS, 10000L));
 
     // some servers do not like requests that are made without a user-agent
     // field, so we provide one


### PR DESCRIPTION
The CI might be slow in responding, remove hardcoded CURLOPT_TIMEOUT, the default is to wait indefinitely:

```
man CURLOPT_TIMEOUT_MS
CURLOPT_TIMEOUT_MS(3)                              Library Functions Manual                             CURLOPT_TIMEOUT_MS(3)

NAME
       CURLOPT_TIMEOUT_MS - maximum time the transfer is allowed to complete
...
DEFAULT
       0 (zero) which means it never times out during transfer.
```

Build jobs started running despite timeout, this should help avoid submitting duplicates.

