### PR TITLE
Include uenv cli in rpm build

### DIFF
--- a/rpm/macros.meson
+++ b/rpm/macros.meson
@@ -20,7 +20,7 @@
 	--mandir=%{_mandir} \\\
 	--infodir=%{_infodir} \\\
 	--localedir=%{_datadir}/locale \\\
-	-Dcli=false \\\
+	-Dcli=true \\\
 	-Dslurm_plugin=true \\\
 	%{nil}
 

--- a/rpm/make-rpm.sh
+++ b/rpm/make-rpm.sh
@@ -86,30 +86,30 @@ mkdir -p "${dstdir}"
 echo SLURM_UENV_MOUNT_VERSION=$SLURM_UENV_MOUNT_VERSION
 echo _scriptdir=$_scriptdir
 echo _projectdir=$_projectdir
-tarball=slurm-uenv-mount-"${SLURM_UENV_MOUNT_VERSION}".tar.gz
+tarball=uenv-"${SLURM_UENV_MOUNT_VERSION}".tar.gz
 
 (
   cd "${dstdir}"
 
   mkdir -p BUILD BUILDROOT RPMS SOURCES SPECS SRPMS
 
-  source_prefix="slurm-uenv-mount-${SLURM_UENV_MOUNT_VERSION}"
+  source_prefix="uenv-${SLURM_UENV_MOUNT_VERSION}"
 
   (
     cd "${_projectdir}"
     git archive --format=tar.gz --output="${dstdir}/SOURCES/${tarball}" HEAD
   )
 
-  cp "${_scriptdir}/slurm-uenv-mount.spec" SPECS/
-  sed -i "s|UENVMNT_VERSION|${SLURM_UENV_MOUNT_VERSION}|g" SPECS/slurm-uenv-mount.spec
-  sed -i "s|RPM_SLURM_VERSION|${RPM_SLURM_VERSION}|g" SPECS/slurm-uenv-mount.spec
+  cp "${_scriptdir}/uenv.spec" SPECS/
+  sed -i "s|UENVMNT_VERSION|${SLURM_UENV_MOUNT_VERSION}|g" SPECS/uenv.spec
+  sed -i "s|RPM_SLURM_VERSION|${RPM_SLURM_VERSION}|g" SPECS/uenv.spec
 
   # create src rpm
-  rpmbuild -bs --define "_topdir ." SPECS/slurm-uenv-mount.spec
+  rpmbuild -bs --define "_topdir ." SPECS/uenv.spec
 
   if [ "${skip_bin}" -eq "0" ]; then
     # create binary rpm
     rpmbuild -vv --nodeps --define "_topdir $(pwd)" \
-             --rebuild SRPMS/slurm-uenv-mount-*.src.rpm
+             --rebuild SRPMS/uenv-*.src.rpm
   fi
 )

--- a/rpm/readme.md
+++ b/rpm/readme.md
@@ -23,7 +23,7 @@ It requires a destination path where the RPM build will occur, and should be run
 
 ## macros.meson
 
-The spec file `slurm-uenv-mount.spec` uses macros like `%meson_setup`, which parameterise
+The spec file `uenv.spec` uses macros like `%meson_setup`, which parameterise
 calls to meson. Macros for meson are not usually available, so we provide a definition of
 the macros in `macros.meson`. They have been modified from the ones provided in the
 following RPM:

--- a/rpm/slurm-uenv-mount.spec
+++ b/rpm/slurm-uenv-mount.spec
@@ -1,11 +1,11 @@
 Name:           slurm-uenv-mount
 Version:        UENVMNT_VERSION
 Release:        RPM_SLURM_VERSION
-Summary:        SLURM spank plugin to mount squashfs images.
+Summary:        UENV cli and SLURM spank plugin.
 Prefix:         /usr
 
 License:        BSD3
-URL:            https://github.com/eth-cscs/slurm-uenv-mount
+URL:            https://github.com/eth-cscs/uenv2
 Source0:        %{name}-%{version}.tar.gz
 
 %define _build_id_links none
@@ -32,3 +32,5 @@ echo "$REQ" > "$CNF"
 %files
 %license LICENSE
 %{_libdir}/lib%{name}.so
+%{_bindir}/uenv
+%{_libexecdir}/oras

--- a/rpm/uenv.spec
+++ b/rpm/uenv.spec
@@ -1,7 +1,7 @@
-Name:           slurm-uenv-mount
+Name:           uenv
 Version:        UENVMNT_VERSION
 Release:        RPM_SLURM_VERSION
-Summary:        UENV cli and SLURM spank plugin.
+Summary:        UENV cli and Slurm spank plugin.
 Prefix:         /usr
 
 License:        BSD3
@@ -11,7 +11,7 @@ Source0:        %{name}-%{version}.tar.gz
 %define _build_id_links none
 
 %description
-A SLURM spank plugin to mount squashfs images.
+UENV cli and Slurm spank plugin.
 
 %prep
 %autosetup -c
@@ -31,6 +31,6 @@ echo "$REQ" > "$CNF"
 
 %files
 %license LICENSE
-%{_libdir}/lib%{name}.so
+%{_libdir}/libslurm-uenv-mount.so
 %{_bindir}/uenv
-%{_libexecdir}/oras
+/usr/libexec/oras

--- a/src/uenv/parse.cpp
+++ b/src/uenv/parse.cpp
@@ -201,7 +201,7 @@ util::expected<uenv_label, parse_error> parse_uenv_label(lexer& L) {
         if (L.current_kind() == tok::at) {
             L.next();
             if (L.current_kind() == tok::star) {
-                result.system = "*";
+                result.system = std::string("*");
                 L.next();
             } else {
                 PARSE(L, name, result.system);


### PR DESCRIPTION
- rename slurm-uenv-mount -> uenv
- change spec file accordingly
- workaround for gcc12 compiler bug (`-Werror`)

The resulting rpm includes the following files, `/usr/libexec` is hardcoded because %libexecdir marco expands to `/usr/lib` on opensuse.:
```
[eiger][simonpi@eiger-ln003 uenv2-rpmbuild]$ rpm -ql uenv-6.0.0-23.11.7.x86_64.rpm
warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.
/usr/bin/uenv
/usr/lib64/libslurm-uenv-mount.so
/usr/libexec/oras
/usr/share/licenses/uenv
/usr/share/licenses/uenv/LICENSE
```