### PR TITLE
add "uenv image copy" command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ subdir('src/uenv')
 if uenv_cli
     uenv_src = [
             'src/cli/add_remove.cpp',
+            'src/cli/copy.cpp',
             'src/cli/find.cpp',
             'src/cli/help.cpp',
             'src/cli/image.cpp',

--- a/src/cli/copy.cpp
+++ b/src/cli/copy.cpp
@@ -1,0 +1,206 @@
+// vim: ts=4 sts=4 sw=4 et
+
+#include <filesystem>
+#include <string>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include <site/site.h>
+#include <uenv/oras.h>
+#include <uenv/parse.h>
+#include <uenv/print.h>
+#include <uenv/repository.h>
+#include <util/curl.h>
+#include <util/expected.h>
+#include <util/fs.h>
+#include <util/signal.h>
+
+#include "copy.h"
+#include "help.h"
+#include "terminal.h"
+
+namespace uenv {
+
+std::string image_copy_footer();
+
+void image_copy_args::add_cli(CLI::App& cli,
+                              [[maybe_unused]] global_settings& settings) {
+    auto* copy_cli =
+        cli.add_subcommand("copy", "copy a uenv inside a remote registry");
+    copy_cli
+        ->add_option("source-uenv", src_uenv_description,
+                     "either name/version:tag, sha256 or id")
+        ->required();
+    copy_cli->add_option("dest-uenv", dst_uenv_description, "label to copy to")
+        ->required();
+    copy_cli->add_option(
+        "--token", token,
+        "a path that contains a TOKEN file for accessing restricted uenv");
+    copy_cli->add_option("--username", username,
+                         "user name for accessing restricted uenv.");
+    copy_cli->add_flag("--force", force,
+                       "overwrite the destination if it exists");
+    copy_cli->callback(
+        [&settings]() { settings.mode = uenv::cli_mode::image_copy; });
+
+    copy_cli->footer(image_copy_footer);
+}
+
+int image_copy([[maybe_unused]] const image_copy_args& args,
+               [[maybe_unused]] const global_settings& settings) {
+    std::optional<uenv::oras::credentials> credentials;
+    if (auto c = site::get_credentials(args.username, args.token)) {
+        credentials = *c;
+    } else {
+        term::error("{}", c.error());
+        return 1;
+    }
+
+    uenv_nslabel src_label{};
+    if (const auto parse = parse_uenv_nslabel(args.src_uenv_description)) {
+        src_label = *parse;
+    } else {
+        term::error("invalid source: {}", parse.error().message());
+        return 1;
+    }
+    if (!src_label.nspace || !src_label.label.name) {
+        term::error("the source uenv {} must provide at least a namespace and "
+                    "name, e.g. 'build::f7076704830c8de7'",
+                    args.src_uenv_description);
+        return 1;
+    }
+    spdlog::debug("source label {}::{}", src_label.nspace, src_label.label);
+
+    uenv_nslabel dst_label{};
+    if (const auto parse = parse_uenv_nslabel(args.dst_uenv_description)) {
+        dst_label = *parse;
+    } else {
+        term::error("invalid destination: {}", parse.error().message());
+        return 1;
+    }
+    spdlog::debug("destination label {}::{}", dst_label.nspace,
+                  dst_label.label);
+    if (!dst_label.nspace) {
+        term::error("the destination uenv {} must provide at least a "
+                    "namespace and name, e.g. 'deploy::'",
+                    args.dst_uenv_description);
+        return 1;
+    }
+
+    auto src_registry = site::registry_listing(*src_label.nspace);
+    if (!src_registry) {
+        term::error("unable to get a listing of the uenv",
+                    src_registry.error());
+        return 1;
+    }
+
+    // search db for matching records
+    const auto src_matches = src_registry->query(src_label.label);
+    if (!src_matches) {
+        term::error("invalid search term: {}", src_registry.error());
+        return 1;
+    }
+    // check that there is one record with a unique sha
+    if (src_matches->empty()) {
+        using enum help::block::admonition;
+        term::error("no uenv found that matches '{}'\n\n{}",
+                    args.src_uenv_description,
+                    help::block(info, "try searching for the uenv to copy "
+                                      "first using 'uenv image find'"));
+        return 1;
+    } else if (!src_matches->unique_sha()) {
+        std::string errmsg =
+            fmt::format("more than one uenv found that matches '{}':\n",
+                        args.src_uenv_description);
+        errmsg += format_record_set(*src_matches);
+        term::error("{}", errmsg);
+        return 1;
+    }
+
+    // pick a record to use for pulling
+    const auto src_record = *(src_matches->begin());
+    spdlog::info("source record: {} {}", src_record.sha, src_record);
+
+    // create the destination record
+    auto dst_record = src_record;
+    {
+        const auto& dl = dst_label.label;
+        if (dl.name) {
+            dst_record.name = *(dl.name);
+        }
+        if (dl.tag) {
+            dst_record.tag = *(dl.tag);
+        }
+        if (dl.version) {
+            dst_record.version = *(dl.version);
+        }
+        if (dl.system) {
+            dst_record.system = *(dl.system);
+        }
+        if (dl.uarch) {
+            dst_record.uarch = *(dl.uarch);
+        }
+    }
+
+    if (dst_record == src_record) {
+        term::error("the source and destination are the same");
+        return 1;
+    }
+
+    spdlog::info("destination record: {} {}", dst_record.sha, dst_record);
+
+    // check whether the destination already exists
+    auto dst_registry = site::registry_listing(*dst_label.nspace);
+    if (dst_registry && dst_registry->contains(dst_record)) {
+        if (!args.force) {
+            term::error("the destination already exists - use the --force flag "
+                        "to copy anyway");
+            return 1;
+        }
+        term::error("the destination already exists and will be overwritten");
+    }
+
+    // TODO: call oras to perform the copy
+    const auto rego_url = site::registry_url();
+    spdlog::debug("registry url: {}", rego_url);
+    if (auto result =
+            oras::copy(rego_url, src_label.nspace.value(), src_record,
+                       dst_label.nspace.value(), dst_record, credentials);
+        !result) {
+        term::error("unable to copy uenv - rerun with -vvv and file a bug");
+        return 1;
+    }
+
+    term::msg("copied {}::{}", src_label.nspace.value(), src_record);
+    term::msg("to     {}::{}", dst_label.nspace.value(), dst_record);
+
+    return 0;
+}
+
+std::string image_copy_footer() {
+    using enum help::block::admonition;
+    std::vector<help::item> items{
+        // clang-format off
+        help::block{none, "Copy a uenv to a new location inside a remote registry." },
+        help::linebreak{},
+        help::linebreak{},
+        help::block{xmpl, "deploy a uenv from build to deploy namespace"},
+        help::block{code,   "uenv image copy prgenv-gnu/24.11:1551223269@todi%gh200 deploy:::v1"},
+        help::block{code,   "uenv image copy 7890d67458ce7deb deploy:::v1"},
+        help::block{none, "when deploying a build, provide a tag."},
+        help::linebreak{},
+        help::block{xmpl, "redeploy a uenv to a new vcluster"},
+        help::block{code,   "uenv image copy 7890d67458ce7deb deploy::@daint"},
+        help::block{code,   "uenv image copy 7890d67458ce7deb @daint"},
+        help::block{none, "in this case, the uenv will deployed with the current tag."},
+        // clang-format on
+    };
+
+    return fmt::format("{}", fmt::join(items, "\n"));
+}
+
+} // namespace uenv

--- a/src/cli/copy.h
+++ b/src/cli/copy.h
@@ -1,0 +1,43 @@
+#pragma once
+// vim: ts=4 sts=4 sw=4 et
+
+#include <optional>
+#include <string>
+
+#include <CLI/CLI.hpp>
+#include <fmt/core.h>
+
+#include <uenv/env.h>
+
+#include "uenv.h"
+
+namespace uenv {
+
+struct image_copy_args {
+    std::string src_uenv_description;
+    std::string dst_uenv_description;
+    std::optional<std::string> token;
+    std::optional<std::string> username;
+    bool force = false;
+    void add_cli(CLI::App&, global_settings& settings);
+};
+
+int image_copy(const image_copy_args& args, const global_settings& settings);
+
+} // namespace uenv
+
+template <> class fmt::formatter<uenv::image_copy_args> {
+  public:
+    // parse format specification and store it:
+    constexpr auto parse(format_parse_context& ctx) {
+        return ctx.end();
+    }
+    // format a value using stored specification:
+    template <typename FmtContext>
+    constexpr auto format(uenv::image_copy_args const& opts,
+                          FmtContext& ctx) const {
+        return fmt::format_to(ctx.out(), "(image pull {} {} .token={})",
+                              opts.src_uenv_description,
+                              opts.dst_uenv_description, opts.token);
+    }
+};

--- a/src/cli/image.cpp
+++ b/src/cli/image.cpp
@@ -13,6 +13,7 @@
 #include <util/shell.h>
 
 #include "add_remove.h"
+#include "copy.h"
 #include "help.h"
 #include "image.h"
 #include "inspect.h"
@@ -29,6 +30,9 @@ void image_args::add_cli(CLI::App& cli,
 
     // add the `uenv image ls` command
     ls_args.add_cli(*image_cli, settings);
+
+    // add the `uenv image copy` command
+    copy_args.add_cli(*image_cli, settings);
 
     // add the `uenv image add` command
     add_args.add_cli(*image_cli, settings);

--- a/src/cli/image.h
+++ b/src/cli/image.h
@@ -5,6 +5,7 @@
 #include <fmt/core.h>
 
 #include "add_remove.h"
+#include "copy.h"
 #include "find.h"
 #include "inspect.h"
 #include "ls.h"
@@ -17,6 +18,7 @@ void image_help();
 
 struct image_args {
     image_add_args add_args;
+    image_copy_args copy_args;
     image_find_args find_args;
     image_inspect_args inspect_args;
     image_ls_args ls_args;

--- a/src/cli/uenv.cpp
+++ b/src/cli/uenv.cpp
@@ -128,6 +128,8 @@ int main(int argc, char** argv) {
         return uenv::image_ls(image.ls_args, settings);
     case settings.image_add:
         return uenv::image_add(image.add_args, settings);
+    case settings.image_copy:
+        return uenv::image_copy(image.copy_args, settings);
     case settings.image_inspect:
         return uenv::image_inspect(image.inspect_args, settings);
     case settings.image_rm:

--- a/src/cli/uenv.h
+++ b/src/cli/uenv.h
@@ -15,6 +15,7 @@ namespace uenv {
 enum class cli_mode : std::uint32_t {
     unset,
     image_add,
+    image_copy,
     image_find,
     image_inspect,
     image_ls,
@@ -65,6 +66,8 @@ template <> class fmt::formatter<uenv::cli_mode> {
             return format_to(ctx.out(), "image-ls");
         case image_add:
             return format_to(ctx.out(), "image-add");
+        case image_copy:
+            return format_to(ctx.out(), "image-copy");
         case image_rm:
             return format_to(ctx.out(), "image-rm");
         case image_find:

--- a/src/site/site.h
+++ b/src/site/site.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 
+#include <uenv/oras.h>
 #include <uenv/repository.h>
 #include <util/expected.h>
 
@@ -21,5 +22,9 @@ util::expected<uenv::repository, std::string>
 registry_listing(const std::string& nspace);
 
 std::string registry_url();
+
+util::expected<std::optional<uenv::oras::credentials>, std::string>
+get_credentials(std::optional<std::string> username,
+                std::optional<std::string> token);
 
 } // namespace site

--- a/src/uenv/oras.h
+++ b/src/uenv/oras.h
@@ -34,6 +34,12 @@ pull_tag(const std::string& registry, const std::string& nspace,
          const uenv_record& uenv, const std::filesystem::path& destination,
          const std::optional<credentials> token = std::nullopt);
 
+util::expected<void, int>
+copy(const std::string& registry, const std::string& src_nspace,
+     const uenv_record& src_uenv, const std::string& dst_nspace,
+     const uenv_record& dst_uenv,
+     const std::optional<credentials> token = std::nullopt);
+
 } // namespace oras
 } // namespace uenv
 

--- a/src/uenv/repository.cpp
+++ b/src/uenv/repository.cpp
@@ -344,6 +344,8 @@ struct repository_impl {
     query(const uenv_label&) const;
     repository::pathset uenv_paths(sha256) const;
 
+    bool contains(const uenv_record&) const;
+
     util::expected<void, std::string> add(const uenv_record&);
     util::expected<record_set, std::string> remove(const uenv_record&);
     util::expected<record_set, std::string> remove(const sha256&);
@@ -625,6 +627,15 @@ repository_impl::remove(const sha256& sha) {
     return *matches;
 }
 
+bool repository_impl::contains(const uenv_record& record) const {
+    auto matches = query({.name = record.name,
+                          .version = record.version,
+                          .tag = record.tag,
+                          .system = record.system,
+                          .uarch = record.uarch});
+    return !matches->empty();
+}
+
 util::expected<record_set, std::string>
 repository_impl::remove(const uenv_record& record) {
     auto matches = query({.name = record.name,
@@ -904,6 +915,10 @@ bool repository::is_readonly() const {
 
 repository::pathset repository::uenv_paths(sha256 sha) const {
     return impl_->uenv_paths(sha);
+}
+
+bool repository::contains(const uenv_record& r) const {
+    return impl_->contains(r);
 }
 
 } // namespace uenv

--- a/src/uenv/repository.h
+++ b/src/uenv/repository.h
@@ -79,6 +79,8 @@ struct repository {
     util::expected<record_set, std::string>
     query(const uenv_label& label) const;
 
+    bool contains(const uenv_record&) const;
+
     util::expected<void, std::string> add(const uenv_record&);
     util::expected<record_set, std::string> remove(const uenv_record&);
     util::expected<record_set, std::string> remove(const sha256&);

--- a/src/util/subprocess.cpp
+++ b/src/util/subprocess.cpp
@@ -21,6 +21,9 @@ expected<pipe, int> make_pipe() {
 }
 
 expected<subprocess, std::string> run(const std::vector<std::string>& argv) {
+    // WARNING: NEVER add logging of the call and its arguments here.
+    // The arguments may contain sensitive information like passwords, and
+    // we rely on the caller printing redacted logs one level up.
     if (argv.empty()) {
         return unexpected("need at least one argument");
     }


### PR DESCRIPTION
`uenv image copy` command

* add token obfuscation to logging output of oras calls
* add `oras::copy` method
* generalise the code for finding oras credentials, as used by both pull and copy commands
* add support for `repository::contains` which verifies whether a record is in a repo