### PR TITLE
Replace message for existing sha in `uenv image pull`

### DIFF
--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -205,6 +205,8 @@ int image_pull([[maybe_unused]] const image_pull_args& args,
             // reraise the signal
             raise(e.signal);
         }
+    } else {
+      term::msg("id={} already exists in the repository, skipping pull. Updating database.", record.id.string());
     }
 
     // add the label to the repo, even if there was no download.

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -206,8 +206,7 @@ int image_pull([[maybe_unused]] const image_pull_args& args,
             raise(e.signal);
         }
     } else {
-        term::msg("id={} already exists in the repository, skipping pull. "
-                  "Updating database.",
+        term::msg("id={} already exists in the repository, skipping pull.",
                   record.id.string());
     }
 

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -205,10 +205,6 @@ int image_pull([[maybe_unused]] const image_pull_args& args,
             // reraise the signal
             raise(e.signal);
         }
-    } else {
-        term::msg("no uenv to pull: the sha\n  {}\nis already in the local "
-                  "repository.",
-                  color::yellow(record.sha.string()));
     }
 
     // add the label to the repo, even if there was no download.

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -206,7 +206,9 @@ int image_pull([[maybe_unused]] const image_pull_args& args,
             raise(e.signal);
         }
     } else {
-      term::msg("id={} already exists in the repository, skipping pull. Updating database.", record.id.string());
+        term::msg("id={} already exists in the repository, skipping pull. "
+                  "Updating database.",
+                  record.id.string());
     }
 
     // add the label to the repo, even if there was no download.


### PR DESCRIPTION
Replace the the message

```
no uenv to pull: the sha\n  {}\nis already in the local "
                  "repository.
```

by

```
[daint][simonpi@daint-ln002 uenv2]$ uenv image pull quantumespresso/v7.3.1:v3@daint
id=1e5e5c4ce6b92fa1 already exists in the repository, skipping pull.
updating quantumespresso/v7.3.1:v3@daint%gh200
```

The former created the impression the cli threw an error and was skipping the db update.
