### PR TITLE
error for unbound variables in bats

### DIFF
--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -2,6 +2,7 @@ function setup() {
     # set the cluster name to be arapiles
     # this is required for tests to work when run on a vCluster
     # that sets this variable
+    set -u
     export CLUSTER_NAME=arapiles
 
     #echo "BATS_LIB_PATH $BATS_LIB_PATH" 1>&3

--- a/test/integration/slurm.bats
+++ b/test/integration/slurm.bats
@@ -2,6 +2,7 @@ function setup() {
     # set the cluster name to be arapiles
     # this is required for tests to work when run on a vCluster
     # that sets this variable
+    set -u
     export CLUSTER_NAME=arapiles
 
     bats_load_library bats-support


### PR DESCRIPTION
add `set -u` to avoid accidental rm -r commands