### PR TITLE
turn flags that take arguments into options in the CLI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## working (since v8.1.0)
+
+- #83 [fix] Turn some CLI flags into options, so that they can be set with or without `=`. e.g. `uenv --repo=$HOME/uenv` or `uenv --repo $HOME/uenv`.

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -89,8 +89,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     // Open the repository
     //
     if (!settings.config.repo) {
-        term::error("a repo needs to be provided either using the --repo flag "
-                    "in the config file");
+        term::error("a repo needs to be provided either using the --repo "
+                    "option, or in the config file");
         return 1;
     }
     auto store = uenv::open_repository(settings.config.repo.value(),

--- a/src/cli/inspect.cpp
+++ b/src/cli/inspect.cpp
@@ -24,7 +24,7 @@ void image_inspect_args::add_cli(CLI::App& cli,
                                  [[maybe_unused]] global_settings& settings) {
     auto* inspect_cli =
         cli.add_subcommand("inspect", "print information about a uenv.");
-    inspect_cli->add_flag("--format", format, "the format string.");
+    inspect_cli->add_option("--format", format, "the format string.");
     inspect_cli->add_option("uenv", label, "the uenv to inspect.")->required();
     inspect_cli->callback(
         [&settings]() { settings.mode = uenv::cli_mode::image_inspect; });

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -132,8 +132,8 @@ int image_pull([[maybe_unused]] const image_pull_args& args,
 
     // require that a valid repo has been provided
     if (!settings.config.repo) {
-        term::error("a repo needs to be provided either using the --repo flag "
-                    "in the config file");
+        term::error("a repo needs to be provided either using the --repo "
+                    "option, or in the config file");
         return 1;
     }
     // open the repo

--- a/src/cli/uenv.cpp
+++ b/src/cli/uenv.cpp
@@ -48,8 +48,8 @@ int main(int argc, char** argv) {
     cli.add_flag_callback(
         "--color", [&cli_config]() -> void { cli_config.color = true; },
         "enable color output");
-    cli.add_flag("--repo", cli_config.repo, "the uenv repository");
     cli.add_flag("--version", print_version, "print version");
+    cli.add_option("--repo", cli_config.repo, "the uenv repository");
 
     cli.footer(help_footer);
 

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -49,7 +49,9 @@ function teardown() {
     assert_output --regexp "app/43.0:v1\s+zen3\s+arapiles"
     assert_output --regexp "tool/17.3.2:v1\s+zen3\s+arapiles"
 
-    run uenv --repo=$REPOS/apptool image ls --no-header
+    # use space instead of = for the --repo option, to check
+    # that both methods work.
+    run uenv --repo $REPOS/apptool image ls --no-header
     assert_success
     refute_line --regexp "^uenv\s+arch\s+system\s+id"
     assert_line --regexp "app/42.0:v1\s+zen3\s+arapiles"
@@ -359,6 +361,11 @@ EOF
 
     # check a format string that contains no fields
     run uenv --repo=$REPOS/apptool image inspect --format='hello world' tool
+    assert_success
+    assert_output "hello world"
+
+    # check that the --format argument works with whitespace instead of =
+    run uenv --repo=$REPOS/apptool image inspect --format 'hello world' tool
     assert_success
     assert_output "hello world"
 


### PR DESCRIPTION
Some options that took arguments, e.g. the `--repo` option were being configured as flags, which require an `=` sign between the flag and value, e.g. `--repo=$HOME`.

Fixes #82 