### PR TITLE
check that meta paths contain env.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,4 @@
 ## working (since v8.1.0)
 
 - #83 [fix] Turn some CLI flags into options, so that they can be set with or without `=`. e.g. `uenv --repo=$HOME/uenv` or `uenv --repo $HOME/uenv`.
+- #87 [fix] Only use meta data path in adjacent to a uenv image if it contains an env.json file.

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -72,10 +72,11 @@ meta_info find_meta_path(const std::filesystem::path& sqfs_path) {
     };
 
     meta_info meta;
-    const auto external_meta_path = sqfs_path.parent_path() / "meta";
-    if (is_valid_meta_path(external_meta_path)) {
-        meta.path = external_meta_path;
-    } else if (auto p = util::unsquashfs_tmp(sqfs_path, "meta");
+
+    if (const auto p = sqfs_path.parent_path() / "meta";
+        is_valid_meta_path(p)) {
+        meta.path = p;
+    } else if (const auto p = util::unsquashfs_tmp(sqfs_path, "meta");
                p && is_valid_meta_path(*p / "meta")) {
         meta.path = *p / "meta";
     }

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -65,12 +65,21 @@ struct meta_info {
 meta_info find_meta_path(const std::filesystem::path& sqfs_path) {
     namespace fs = std::filesystem;
 
+    // this test checks whether the meta path contains env.json.
+    // extend in the future to check for other required files, as needed.
+    auto is_valid_meta_path = [](const std::filesystem::path& path) -> bool {
+        return fs::is_regular_file(path / "env.json");
+    };
+
     meta_info meta;
-    if (fs::is_directory(sqfs_path.parent_path() / "meta")) {
-        meta.path = sqfs_path.parent_path() / "meta";
-    } else if (auto p = util::unsquashfs_tmp(sqfs_path, "meta")) {
+    const auto external_meta_path = sqfs_path.parent_path() / "meta";
+    if (is_valid_meta_path(external_meta_path)) {
+        meta.path = external_meta_path;
+    } else if (auto p = util::unsquashfs_tmp(sqfs_path, "meta");
+               p && is_valid_meta_path(*p / "meta")) {
         meta.path = *p / "meta";
     }
+
     if (meta.path) {
         spdlog::debug("find_meta_path: {} found meta path {}",
                       sqfs_path.string(), meta.path->string());


### PR DESCRIPTION
Check that meta paths contain env.json before accepting them.
This will force uenv to fall back to the unsquashed meta data when
* a user has created a dummy meta path with a reframe.yaml file for test writing
* if scratch cleanup has removed the env.json file

We still prefer the external meta path, because this lets uenv authors test and tweak the meta data without rebuilding a uenv, as part of uenv development and testing.

Fixes #85 