### PR TITLE
add --format flag to uenv status

### DIFF
--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -88,16 +88,16 @@ int status([[maybe_unused]] const status_args& args,
     }
 
     if (args.use_short) {
-        std::unordered_map<std::string, std::vector<std::string>> entries;
+        std::unordered_map<std::string, std::vector<std::string>> uenv_views;
         for (auto x : env->views) {
-            entries.try_emplace(x.uenv, std::vector<std::string>{});
-            entries[x.uenv].push_back(x.name);
+            uenv_views.try_emplace(x.uenv, std::vector<std::string>{});
+            uenv_views[x.uenv].push_back(x.name);
         }
-        auto name_views = entries | std::views::transform([](const auto& pair) {
-          const auto& [name, views] = pair;
-                              return fmt::format("{}:{}", name,
-                                                 fmt::join(views, ","));
-                          });
+        auto name_views =
+            uenv_views | std::views::transform([](const auto& pair) {
+                const auto& [name, views] = pair;
+                return fmt::format("{}:{}", name, fmt::join(views, ","));
+            });
         term::msg("{}", fmt::join(name_views, "|"));
         return 0;
     }

--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <ranges>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <fmt/core.h>
@@ -87,7 +88,17 @@ int status([[maybe_unused]] const status_args& args,
     }
 
     if (args.use_short) {
-        term::msg("{}", fmt::join(env->uenvs | std::views::keys, ","));
+        std::unordered_map<std::string, std::vector<std::string>> entries;
+        for (auto x : env->views) {
+            entries.try_emplace(x.uenv, std::vector<std::string>{});
+            entries[x.uenv].push_back(x.name);
+        }
+        auto name_views = entries | std::views::transform([](const auto& pair) {
+          const auto& [name, views] = pair;
+                              return fmt::format("{}:{}", name,
+                                                 fmt::join(views, ","));
+                          });
+        term::msg("{}", fmt::join(name_views, "|"));
         return 0;
     }
 

--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -115,6 +115,10 @@ int status([[maybe_unused]] const status_args& args,
     } else if (args.format == "views") {
         // print `<name1>:<view1>|..|<nameN>:<viewN>`
         std::unordered_map<std::string, std::vector<std::string>> uenv_views;
+        // make sure there is an empty list for a mounted uenv without activated view
+        for (auto x : env->uenvs) {
+          uenv_views.try_emplace(x.first, std::vector<std::string>{});
+        }
         for (auto x : env->views) {
             uenv_views.try_emplace(x.uenv, std::vector<std::string>{});
             uenv_views[x.uenv].push_back(x.name);

--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -115,9 +115,10 @@ int status([[maybe_unused]] const status_args& args,
     } else if (args.format == "views") {
         // print `<name1>:<view1>|..|<nameN>:<viewN>`
         std::unordered_map<std::string, std::vector<std::string>> uenv_views;
-        // make sure there is an empty list for a mounted uenv without activated view
+        // make sure there is an entry also for a mounted uenv without activated
+        // view
         for (auto x : env->uenvs) {
-          uenv_views.try_emplace(x.first, std::vector<std::string>{});
+            uenv_views.try_emplace(x.first, std::vector<std::string>{});
         }
         for (auto x : env->views) {
             uenv_views.try_emplace(x.uenv, std::vector<std::string>{});
@@ -126,6 +127,9 @@ int status([[maybe_unused]] const status_args& args,
         auto name_views =
             uenv_views | std::views::transform([](const auto& pair) {
                 const auto& [name, views] = pair;
+                if (views.size() == 0) {
+                    return fmt::format("{}", name);
+                }
                 return fmt::format("{}:{}", name, fmt::join(views, ","));
             });
         term::msg("{}", fmt::join(name_views, "|"));

--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -48,7 +48,7 @@ int status([[maybe_unused]] const status_args& args,
 
     if (!in_uenv_session(settings.calling_environment)) {
         // --short is silent if no uenv is loaded
-        if (!(args.format == "full")) {
+        if (args.format == "full") {
             term::msg("there is no uenv loaded");
         }
         return 0;

--- a/src/cli/status.cpp
+++ b/src/cli/status.cpp
@@ -48,7 +48,7 @@ int status([[maybe_unused]] const status_args& args,
 
     if (!in_uenv_session(settings.calling_environment)) {
         // --short is silent if no uenv is loaded
-        if (!(args.format == "short")) {
+        if (!(args.format == "full")) {
             term::msg("there is no uenv loaded");
         }
         return 0;

--- a/src/cli/status.h
+++ b/src/cli/status.h
@@ -8,7 +8,7 @@
 namespace uenv {
 
 struct status_args {
-    bool use_short{false};
+    std::string format;
     void add_cli(CLI::App&, global_settings& settings);
 };
 

--- a/src/cli/status.h
+++ b/src/cli/status.h
@@ -8,6 +8,7 @@
 namespace uenv {
 
 struct status_args {
+    bool use_short{false};
     void add_cli(CLI::App&, global_settings& settings);
 };
 

--- a/src/cli/status.h
+++ b/src/cli/status.h
@@ -7,8 +7,12 @@
 
 namespace uenv {
 
+enum class status_format { name, full, views };
+
 struct status_args {
-    std::string format;
+    status_format format = status_format::full;
+    // return nonzero value when no uenv is loaded
+    bool error_if_unset = false;
     void add_cli(CLI::App&, global_settings& settings);
 };
 

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -125,6 +125,22 @@ function teardown() {
     assert_equal "$jq_output" "0"
 }
 
+@test "status" {
+    export RP=$REPOS/apptool
+
+    run uenv --repo=$RP status
+    assert_success
+    assert_line --index 0 "there is no uenv loaded"
+
+    run uenv --repo=$RP status --format=name
+    assert_success
+    run uenv --repo=$RP status --format=views
+    assert_success
+
+    run uenv --repo=$RP status --error-if-unset
+    assert_failure
+}
+
 @test "repo status" {
     export RP=$REPOS/apptool
 

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -132,7 +132,7 @@ function teardown() {
     assert_success
     assert_line --index 0 "there is no uenv loaded"
 
-    run uenv --repo=$RP status --format=name
+    run uenv --repo=$RP status --format=short
     assert_success
     run uenv --repo=$RP status --format=views
     assert_success


### PR DESCRIPTION
`uenv status --format`:
```
[daint][simonpi@daint-ln003 uenv2]$ uenv status --format=full
editors:/user-tools
  text editors and handy command line tools
  views:
    spack: configure spack upstream
    modules: activate modules
    ed (loaded): 
prgenv-gnu:/user-environment
  GNU Compiler toolchain with cray-mpich, Python, CMake and other development tools.
  views:
    spack: configure spack upstream
    modules: activate modules
    default: 
```

`--format=short`
```
[daint][simonpi@daint-ln003 uenv2]$ uenv status --format=short
editors|prgenv-gnu
```

`--format=views`
```
[daint][simonpi@daint-ln003 uenv2]$ uenv status --format=views
prgenv-gnu|editors:ed
```