### PR TITLE
Forward bash functions correctly

### DIFF
--- a/src/squashfs-mount/squashfs-mount.cpp
+++ b/src/squashfs-mount/squashfs-mount.cpp
@@ -138,13 +138,21 @@ int main(int argc, char** argv, char** envp) {
     // forward all environment variables not prefixed with SQFSMNT_FWD_
     for (auto& [name, v] : calling_env.variables()) {
         if (!name.starts_with("SQFSMNT_FWD_")) {
-            runtime_env.set(name, v);
+            // use forward instead of set, becase set drops environment
+            // variables that do not have valid POSIX compliant names.
+            // In this context we need to tolerate all possible names to fully
+            // reproduce the calling environment.
+            // For example: bash function exports do not follow the POSIX standard.
+            runtime_env.forward(name, v);
         }
     }
     // add the forwarded variables in a second loop, in case a variable with the
     // same name was already in the calling environment.
     for (auto& [name, v] : calling_env.variables()) {
         if (name.starts_with("SQFSMNT_FWD_")) {
+            // use set, which will still drop environment variables with invalid
+            // names, because an invalid name in this context is certainly a bug
+            // in the caller.
             runtime_env.set(name.substr(12), v);
         }
     }

--- a/src/squashfs-mount/squashfs-mount.cpp
+++ b/src/squashfs-mount/squashfs-mount.cpp
@@ -142,7 +142,9 @@ int main(int argc, char** argv, char** envp) {
             // variables that do not have valid POSIX compliant names.
             // In this context we need to tolerate all possible names to fully
             // reproduce the calling environment.
-            // For example: bash function exports do not follow the POSIX standard.
+            // For example: bash function exports do not follow the POSIX
+            // standard.
+
             runtime_env.forward(name, v);
         }
     }

--- a/src/util/envvars.h
+++ b/src/util/envvars.h
@@ -55,6 +55,7 @@ class state {
     state(const state&) = default;
 
     void set(std::string_view name, std::string_view value);
+    void forward(std::string_view name, std::string_view value);
     void unset(std::string_view name);
     std::optional<std::string> get(std::string_view name) const;
 

--- a/test/integration/readme.md
+++ b/test/integration/readme.md
@@ -4,23 +4,48 @@ Integration test for the CLI and SLURM plugin, using the [bats](https://github.c
 
 ## getting started
 
-Before running tests, first download bats:
+The best way to run the tests is to configure the meson build with tests enabled:
 
-```console
-./install-bats
 ```
+meson setup .. -Dtests=enabled
+```
+
+This will generate the test inputs in the `test` subdirectory of the build path, and install the test runners
 
 ## running the tests
 
-There are two separate sets of tests.
+There are three separate sets of tests.
 
 - `slurm.bats`: test the slurm plugin
     - ensure that you have built the plugin and configured slurm in your environment to use the plugin.
 - `cli.bats`: test the uenv cli
     - ensure that you have built the cli and that it is in your `PATH`.
+- `squashfs-mount.bats`: test the squashfs-mount cli tool
+    - the tool is setuid, so an additional installation step is required (see below)
 
-To run the respective tests, use the copy of bats installed in this path using the `./install-bats` script above:
+To run the respective tests, build with `-Dtests=enabled`, then in the build path:
 ```console
-./bats ./slurm.bats
-./bats ./cli.bats
+./test/bats ./test/slurm.bats
+./test/bats ./test/cli.bats
+```
+
+## testing squashfs-mount
+
+```bash
+# create a staging path where we will install 
+export STAGING_PATH=$PWD/staging
+meson setup .. -Dtests=enabled -Dsquashfs_mount=true --prefix=$STAGING_PATH
+# build as user
+meson compile
+# install in the staging path as root (required to make squashfs-mount setuid)
+sudo meson install --no-rebuild --skip-subprojects
+
+# run the tests
+# the test framework will detect the STAGING_PATH variable and use the uenv and squashfs-mount
+# executables installed therein.
+
+# test the cli with the version squashfs-mount installed in staging
+./test/bats ./test/cli.bats
+# test squashfs-mount
+./test/bats ./test/squashfs-mount.bats
 ```

--- a/test/integration/slurm.bats
+++ b/test/integration/slurm.bats
@@ -124,6 +124,16 @@ function teardown() {
     unset TOOLCONFLICT
 }
 
+@test "fwd_non_posix_envvars" {
+    export RP=$REPOS/apptool
+
+    # check that exported bash functions (which have non-posix names) are forwarded correctly
+    hello() { echo "hello world $1"; }
+    export -f hello
+    run_srun_unchecked --repo=$RP --uenv=app/42.0 --view=app bash -c 'hello hpc'
+    assert_output "hello world hpc"
+}
+
 # check for invalid arguments passed to --uenv
 @test "faulty --uenv argument" {
     export RP=$REPOS/apptool
@@ -239,3 +249,4 @@ echo "should not get here"
 EOF
     [ "${status}" -eq "1" ]
 }
+

--- a/test/integration/squashfs-mount.bats
+++ b/test/integration/squashfs-mount.bats
@@ -49,6 +49,18 @@ function teardown() {
     assert_output "LD_LIBRARY_PATH=foo"
 }
 
+@test "fwd_non_posix_envvars" {
+    # check that exported bash functions (which have non-posix names) are forwarded correctly
+    hello() { echo "hello world $1"; }
+    export -f hello
+    run squashfs-mount -- bash -c 'hello hpc'
+    assert_output "hello world hpc"
+
+    # check that non-posix names are forwarded
+    run env 'SCRATCH.OLD=/capstor/scratch/robert' squashfs-mount -- printenv 'SCRATCH.OLD'
+    assert_output "/capstor/scratch/robert"
+}
+
 @test "mount_single_image" {
     SQFS_PATH=$SQFS_LIB/apptool/standalone
     run squashfs-mount --sqfs=$SQFS_PATH/app42.squashfs:/user-environment -- /user-environment/env/app/bin/app


### PR DESCRIPTION
The new squashfs-mount implementation was filtering env. variables with non-standard names when forwarding them to the target environment.

