### PR TITLE
allow adding image with sqfs file from internal store

### DIFF
--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -78,9 +78,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
 
     spdlog::info("image_add: label {}", *label);
 
-    const auto env =
-        concretise_env(args.squashfs, {},
-                       settings.config.repo, settings.calling_environment);
+    const auto env = concretise_env(args.squashfs, {}, settings.config.repo,
+                                    settings.calling_environment);
     if (!env) {
         term::error("{}", env.error());
         return 1;
@@ -90,7 +89,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
         return 1;
     }
 
-    auto sqfs = uenv::validate_squashfs_image(env->uenvs.begin()->second.sqfs_path);
+    auto sqfs =
+        uenv::validate_squashfs_image(env->uenvs.begin()->second.sqfs_path);
     if (!sqfs) {
         term::error("invalid squashfs file {}: {}", args.squashfs,
                     sqfs.error());
@@ -159,8 +159,10 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     const auto uenv_paths = store->uenv_paths(sqfs->hash);
     uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
 
-    // fs::equivalent only works on existing files, check first if path even exists, and only then for equivalence
-    if (!fs::exists(uenv_paths.squashfs) || !fs::equivalent(uenv_paths.squashfs, sqfs->sqfs)) {
+    // fs::equivalent only works on existing files, check first if path even
+    // exists, and only then for equivalence
+    if (!fs::exists(uenv_paths.squashfs) ||
+        !fs::equivalent(uenv_paths.squashfs, sqfs->sqfs)) {
         //
         // create the path inside the repo
         //
@@ -174,8 +176,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
 
         fs::create_directories(uenv_paths.store, ec);
         if (ec) {
-            spdlog::error("unable to create path {}: {}", uenv_paths.store.string(),
-                          ec.message());
+            spdlog::error("unable to create path {}: {}",
+                          uenv_paths.store.string(), ec.message());
             term::error("unable to add the uenv");
             return 1;
         }
@@ -211,14 +213,14 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                 spdlog::error("unable to move squashfs image {} to {}: {}",
                               sqfs->sqfs.string(), uenv_paths.squashfs.string(),
                               ec.message());
-                term::error(
-                    "unable to add the uenv\n{}",
-                    help::item{help::block{
-                        help::block::admonition::note,
-                        fmt::format(
-                            "check that the file {} is on the same filesystem as "
-                            "the repository, and that you have write access to it.",
-                            sqfs->sqfs.string())}});
+                term::error("unable to add the uenv\n{}",
+                            help::item{help::block{
+                                help::block::admonition::note,
+                                fmt::format("check that the file {} is on the "
+                                            "same filesystem as "
+                                            "the repository, and that you have "
+                                            "write access to it.",
+                                            sqfs->sqfs.string())}});
                 return 1;
             }
         }

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -159,7 +159,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     const auto uenv_paths = store->uenv_paths(sqfs->hash);
     uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
 
-    bool source_in_repo = util::is_child(sqfs->sqfs, settings.config.repo.value());
+    bool source_in_repo =
+        util::is_child(sqfs->sqfs, settings.config.repo.value());
     if (!source_in_repo) {
         //
         // create the path inside the repo

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -159,10 +159,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     const auto uenv_paths = store->uenv_paths(sqfs->hash);
     uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
 
-    // fs::equivalent only works on existing files, check first if path even
-    // exists, and only then for equivalence
-    if (!fs::exists(uenv_paths.squashfs) ||
-        !fs::equivalent(uenv_paths.squashfs, sqfs->sqfs)) {
+    bool source_in_repo = util::is_child(sqfs->sqfs, settings.config.repo.value());
+    if (!source_in_repo) {
         //
         // create the path inside the repo
         //

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -7,6 +7,7 @@
 #include <fmt/std.h>
 #include <spdlog/spdlog.h>
 
+#include <uenv/env.h>
 #include <uenv/parse.h>
 #include <uenv/print.h>
 #include <uenv/repository.h>
@@ -77,7 +78,19 @@ int image_add(const image_add_args& args, const global_settings& settings) {
 
     spdlog::info("image_add: label {}", *label);
 
-    auto sqfs = uenv::validate_squashfs_image(args.squashfs);
+    const auto env =
+        concretise_env(args.squashfs, {},
+                       settings.config.repo, settings.calling_environment);
+    if (!env) {
+        term::error("{}", env.error());
+        return 1;
+    }
+    if (env->uenvs.size() != 1) {
+        term::error("Too many arguments provided for source squashfs file");
+        return 1;
+    }
+
+    auto sqfs = uenv::validate_squashfs_image(env->uenvs.begin()->second.sqfs_path);
     if (!sqfs) {
         term::error("invalid squashfs file {}: {}", args.squashfs,
                     sqfs.error());
@@ -144,67 +157,70 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     }
 
     const auto uenv_paths = store->uenv_paths(sqfs->hash);
-
-    //
-    // create the path inside the repo
-    //
-    std::error_code ec;
-    // if the path exists, delete it, as it might contain a partial download
-    if (fs::exists(uenv_paths.store)) {
-        spdlog::debug("image_add: remove the target path {} before copying",
-                      uenv_paths.store.string());
-        fs::remove_all(uenv_paths.store);
-    }
     uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
 
-    fs::create_directories(uenv_paths.store, ec);
-    if (ec) {
-        spdlog::error("unable to create path {}: {}", uenv_paths.store.string(),
-                      ec.message());
-        term::error("unable to add the uenv");
-        return 1;
-    }
-
-    //
-    // copy the meta data into the repo
-    //
-    if (sqfs->meta) {
-        fs::copy_options options{};
-        options |= fs::copy_options::recursive;
-        fs::copy(sqfs->meta.value(), uenv_paths.meta, options, ec);
-        if (ec) {
-            spdlog::error("unable to copy meta data to {}: {}",
-                          uenv_paths.meta.string(), ec.message());
-            term::error("unable to add the uenv");
-            return 1;
+    // fs::equivalent only works on existing files, check first if path even exists, and only then for equivalence
+    if (!fs::exists(uenv_paths.squashfs) || !fs::equivalent(uenv_paths.squashfs, sqfs->sqfs)) {
+        //
+        // create the path inside the repo
+        //
+        std::error_code ec;
+        // if the path exists, delete it, as it might contain a partial download
+        if (fs::exists(uenv_paths.store)) {
+            spdlog::debug("image_add: remove the target path {} before copying",
+                          uenv_paths.store.string());
+            fs::remove_all(uenv_paths.store);
         }
-    }
 
-    // copy or move the
-    if (!args.move) {
-        fs::copy_file(sqfs->sqfs, uenv_paths.squashfs, ec);
+        fs::create_directories(uenv_paths.store, ec);
         if (ec) {
-            spdlog::error("unable to copy squashfs image {} to {}: {}",
-                          sqfs->sqfs.string(), uenv_paths.squashfs.string(),
+            spdlog::error("unable to create path {}: {}", uenv_paths.store.string(),
                           ec.message());
             term::error("unable to add the uenv");
             return 1;
         }
-    } else {
-        fs::rename(sqfs->sqfs, uenv_paths.squashfs, ec);
-        if (ec) {
-            spdlog::error("unable to move squashfs image {} to {}: {}",
-                          sqfs->sqfs.string(), uenv_paths.squashfs.string(),
-                          ec.message());
-            term::error(
-                "unable to add the uenv\n{}",
-                help::item{help::block{
-                    help::block::admonition::note,
-                    fmt::format(
-                        "check that the file {} is on the same filesystem as "
-                        "the repository, and that you have write access to it.",
-                        sqfs->sqfs.string())}});
-            return 1;
+
+        //
+        // copy the meta data into the repo
+        //
+        if (sqfs->meta) {
+            fs::copy_options options{};
+            options |= fs::copy_options::recursive;
+            fs::copy(sqfs->meta.value(), uenv_paths.meta, options, ec);
+            if (ec) {
+                spdlog::error("unable to copy meta data to {}: {}",
+                              uenv_paths.meta.string(), ec.message());
+                term::error("unable to add the uenv");
+                return 1;
+            }
+        }
+
+        // copy or move the
+        if (!args.move) {
+            fs::copy_file(sqfs->sqfs, uenv_paths.squashfs, ec);
+            if (ec) {
+                spdlog::error("unable to copy squashfs image {} to {}: {}",
+                              sqfs->sqfs.string(), uenv_paths.squashfs.string(),
+                              ec.message());
+                term::error("unable to add the uenv");
+                return 1;
+            }
+        } else {
+            fs::rename(sqfs->sqfs, uenv_paths.squashfs, ec);
+            if (ec) {
+                spdlog::error("unable to move squashfs image {} to {}: {}",
+                              sqfs->sqfs.string(), uenv_paths.squashfs.string(),
+                              ec.message());
+                term::error(
+                    "unable to add the uenv\n{}",
+                    help::item{help::block{
+                        help::block::admonition::note,
+                        fmt::format(
+                            "check that the file {} is on the same filesystem as "
+                            "the repository, and that you have write access to it.",
+                            sqfs->sqfs.string())}});
+                return 1;
+            }
         }
     }
 

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -246,4 +246,9 @@ read_single_line_file(const std::filesystem::path& path) {
     return std::nullopt;
 }
 
+bool is_child(const std::filesystem::path& child, const std::filesystem::path& parent) {
+    auto rel = child.lexically_relative(parent);
+    return !rel.empty() && *rel.begin() != "..";
+}
+
 } // namespace util

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -246,7 +246,8 @@ read_single_line_file(const std::filesystem::path& path) {
     return std::nullopt;
 }
 
-bool is_child(const std::filesystem::path& child, const std::filesystem::path& parent) {
+bool is_child(const std::filesystem::path& child,
+              const std::filesystem::path& parent) {
     auto rel = child.lexically_relative(parent);
     return !rel.empty() && *rel.begin() != "..";
 }

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -64,6 +64,7 @@ std::optional<std::string>
 read_single_line_file(const std::filesystem::path& path);
 
 // return if a path is inside a directory, i.e. direct or indirect child
-bool is_child(const std::filesystem::path& child, const std::filesystem::path& parent);
+bool is_child(const std::filesystem::path& child,
+              const std::filesystem::path& parent);
 
 } // namespace util

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -63,4 +63,7 @@ file_level file_access_level(const std::filesystem::path& path);
 std::optional<std::string>
 read_single_line_file(const std::filesystem::path& path);
 
+// return if a path is inside a directory, i.e. direct or indirect child
+bool is_child(const std::filesystem::path& child, const std::filesystem::path& parent);
+
 } // namespace util

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -381,9 +381,6 @@ EOF
     run uenv --repo=$RP image ls --no-header
     assert_success
     assert_line --partial 'wombat/24:v1'
-    assert_line --partial 'numbat/24:v1'
-    assert_line --partial 'bilby/24:v1'
-    assert_line --partial 'quokka/24:v1'
     assert_line --partial 'wombat/24:replica'
     [ "${#lines[@]}" -eq "5" ]
 
@@ -395,11 +392,7 @@ EOF
 
     run uenv --repo=$RP image ls --no-header
     assert_success
-    assert_line --partial 'wombat/24:v1'
     assert_line --partial 'numbat/24:v1'
-    assert_line --partial 'bilby/24:v1'
-    assert_line --partial 'quokka/24:v1'
-    assert_line --partial 'wombat/24:replica'
     assert_line --partial 'numbat/24:replica'
     [ "${#lines[@]}" -eq "6" ]
 

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -372,6 +372,37 @@ EOF
     assert_line --partial 'quokka/24:v1'
     [ "${#lines[@]}" -eq "4" ]
 
+    # trying to add the same image with a different label pointing to an SQFS file inside the repo should generate a warning
+    run uenv --repo=$RP image add wombat/24:replica@arapiles%zen3 $(uenv --repo=$RP image inspect --format='{sqfs}' wombat/24:v1@arapiles%zen3)
+    assert_success
+    assert_output --partial "warning"
+    assert_output --partial "a uenv with the same sha"
+
+    run uenv --repo=$RP image ls --no-header
+    assert_success
+    assert_line --partial 'wombat/24:v1'
+    assert_line --partial 'numbat/24:v1'
+    assert_line --partial 'bilby/24:v1'
+    assert_line --partial 'quokka/24:v1'
+    assert_line --partial 'wombat/24:replica'
+    [ "${#lines[@]}" -eq "5" ]
+
+    # trying to add the same image by label
+    run uenv --repo=$RP image add numbat/24:replica@arapiles%zen3 numbat/24:v1
+    assert_success
+    assert_output --partial "warning"
+    assert_output --partial "a uenv with the same sha"
+
+    run uenv --repo=$RP image ls --no-header
+    assert_success
+    assert_line --partial 'wombat/24:v1'
+    assert_line --partial 'numbat/24:v1'
+    assert_line --partial 'bilby/24:v1'
+    assert_line --partial 'quokka/24:v1'
+    assert_line --partial 'wombat/24:replica'
+    assert_line --partial 'numbat/24:replica'
+    [ "${#lines[@]}" -eq "6" ]
+
     # TODO:
     # - check a read-only repo
 }

--- a/test/unit/fs.cpp
+++ b/test/unit/fs.cpp
@@ -119,3 +119,26 @@ TEST_CASE("read_single_line_file", "[fs]") {
         REQUIRE(r.value() == "hello world");
     }
 }
+
+TEST_CASE("is_child", "[fs]") {
+    // direct child
+    {
+        const std::filesystem::path child = "/path/to/child";
+        const std::filesystem::path parent = "/path/to";
+        REQUIRE(util::is_child(child, parent));
+    }
+
+    // indirect child
+    {
+        const std::filesystem::path child = "/path/to/child";
+        const std::filesystem::path parent = "/path";
+        REQUIRE(util::is_child(child, parent));
+    }
+
+    // not a child
+    {
+        const std::filesystem::path child = "/path/to/child";
+        const std::filesystem::path parent = "/tmp";
+        REQUIRE(!util::is_child(child, parent));
+    }
+}


### PR DESCRIPTION
This fixes #15 
It does not fail anymore when referencing an internal sqfs file. Additionally it allows to retag by label, i.e. this is equivalent:
```
uenv image add numbat:24/v1 wombat:24/v1
uenv image add numbat:24/v1 $(uenv --repo=$RP image inspect --format='{sqfs}' wombat/24:v1@arapiles%zen3)
```