### PR TITLE
partial name matches in ls and find

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- #129 [feature] `uenv image find` and `uenv image ls` do partial match on uenv names
 - #127 [feature] find views, mount point, etc. information using `uenv image inspect` without opening a uenv.
 
 ## 9.1.2

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -369,7 +369,7 @@ int image_rm([[maybe_unused]] const image_rm_args& args,
             } else if (r->size() > 1) {
                 term::error("the pattern {} matches more than one "
                             "uenv:\n{}use a more specific version",
-                            U, format_record_set(*r));
+                            U, format_record_set_list(*r));
                 return 1;
             } else {
                 // check whether there are more than one tag attached to sha
@@ -411,7 +411,7 @@ int image_rm([[maybe_unused]] const image_rm_args& args,
     } else {
         term::msg("the following uenv {} removed:",
                   (removed.size() > 1 ? "were" : "was"));
-        print_record_set(removed, true);
+        print_record_set(removed, record_set_format::list);
     }
 
     return 0;

--- a/src/cli/copy.cpp
+++ b/src/cli/copy.cpp
@@ -116,7 +116,7 @@ int image_copy([[maybe_unused]] const image_copy_args& args,
         std::string errmsg =
             fmt::format("more than one uenv found that matches '{}':\n",
                         args.src_uenv_description);
-        errmsg += format_record_set(*src_matches);
+        errmsg += format_record_set_table(*src_matches);
         term::error("{}", errmsg);
         return 1;
     }

--- a/src/cli/delete.cpp
+++ b/src/cli/delete.cpp
@@ -102,7 +102,7 @@ int image_delete([[maybe_unused]] const image_delete_args& args,
         std::string errmsg =
             fmt::format("more than one sha found that matches '{}':\n",
                         args.uenv_description);
-        errmsg += format_record_set(*matches);
+        errmsg += format_record_set_table(*matches);
         term::error("{}", errmsg);
         return 1;
     }

--- a/src/cli/find.h
+++ b/src/cli/find.h
@@ -13,6 +13,8 @@ struct image_find_args {
     std::optional<std::string> uenv_description;
     bool no_header = false;
     bool json = false;
+    bool list = false;
+    bool no_partials = false;
     bool build = false;
     void add_cli(CLI::App&, global_settings& settings);
 };

--- a/src/cli/ls.h
+++ b/src/cli/ls.h
@@ -13,6 +13,8 @@ struct image_ls_args {
     std::optional<std::string> uenv_description;
     bool no_header = false;
     bool json = false;
+    bool list = false;
+    bool no_partials = false;
     void add_cli(CLI::App&, global_settings& settings);
 };
 
@@ -32,7 +34,9 @@ template <> class fmt::formatter<uenv::image_ls_args> {
     template <typename FmtContext>
     constexpr auto format(uenv::image_ls_args const& opts,
                           FmtContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{{uenv: '{}'}}",
-                              opts.uenv_description);
+        return fmt::format_to(
+            ctx.out(),
+            "{{uenv: '{}', json: {}, no_partials: {}, no_header: {}}}",
+            opts.uenv_description, opts.json, opts.no_partials, opts.no_header);
     }
 };

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -121,7 +121,7 @@ int image_pull([[maybe_unused]] const image_pull_args& args,
         std::string errmsg =
             fmt::format("more than one uenv found that matches '{}':\n",
                         args.uenv_description);
-        errmsg += format_record_set(*remote_matches);
+        errmsg += format_record_set_table(*remote_matches);
         term::error("{}", errmsg);
         return 1;
     }

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -160,7 +160,7 @@ resolve_uenv(const uenv_description& desc,
                 fmt::format("more than one uenv matches the uenv description "
                             "'{}':\n",
                             desc.label().value());
-            errmsg += format_record_set(results);
+            errmsg += format_record_set_table(results);
             return unexpected(errmsg);
         }
 

--- a/src/uenv/print.cpp
+++ b/src/uenv/print.cpp
@@ -3,13 +3,14 @@
 #include <fmt/std.h>
 #include <nlohmann/json.hpp>
 
+#include <uenv/print.h>
 #include <uenv/repository.h>
 #include <uenv/uenv.h>
 #include <util/color.h>
 
 namespace uenv {
 
-std::string format_record_set(const record_set& records, bool no_header) {
+std::string format_record_set_table(const record_set& records, bool no_header) {
     if (!no_header && records.empty()) {
         if (!no_header) {
             return "no matching uenv\n";
@@ -62,6 +63,16 @@ std::string format_record_set(const record_set& records, bool no_header) {
     return result;
 }
 
+std::string format_record_set_list(const record_set& records) {
+    std::string result;
+    for (auto& r : records) {
+        result += fmt::format("{}/{}:{}@{}%{}\n", r.name, r.version, r.tag,
+                              r.system, r.uarch);
+    }
+
+    return result;
+}
+
 std::string format_record_set_json(const record_set& records) {
     using nlohmann::json;
     std::vector<json> jrecords;
@@ -79,9 +90,21 @@ std::string format_record_set_json(const record_set& records) {
     return json{{"records", jrecords}}.dump();
 }
 
-void print_record_set(const record_set& records, bool no_header, bool json) {
-    fmt::print("{}", json ? format_record_set_json(records)
-                          : format_record_set(records, no_header));
+void print_record_set(const record_set& records, record_set_format f) {
+    switch (f) {
+    case record_set_format::json:
+        fmt::print("{}", format_record_set_json(records));
+        return;
+    case record_set_format::list:
+        fmt::print("{}", format_record_set_list(records));
+        return;
+    case record_set_format::table:
+        fmt::print("{}", format_record_set_table(records, false));
+        return;
+    case record_set_format::table_no_header:
+        fmt::print("{}", format_record_set_table(records, true));
+        return;
+    }
 }
 
 } // namespace uenv

--- a/src/uenv/print.h
+++ b/src/uenv/print.h
@@ -1,10 +1,22 @@
 #pragma once
 
 #include <uenv/repository.h>
+#include <util/expected.h>
 
 namespace uenv {
-void print_record_set(const record_set& result, bool no_header = true,
-                      bool json = false);
-std::string format_record_set(const record_set& records, bool no_header = true);
+
+enum class record_set_format { table, table_no_header, json, list };
+
+void print_record_set(const record_set& result, record_set_format format);
+
+std::string format_record_set_table(const record_set& records,
+                                    bool no_header = true);
+std::string format_record_set_list(const record_set& records);
 std::string format_record_set_json(const record_set& records);
+
+// a helper for determining the output format based on CLI flags:
+// --no-header, --json and --list
+util::expected<record_set_format, std::string>
+get_record_set_format(bool no_header, bool json, bool list);
+
 } // namespace uenv

--- a/src/uenv/repository.h
+++ b/src/uenv/repository.h
@@ -89,7 +89,10 @@ struct repository {
     std::optional<std::filesystem::path> path() const;
 
     util::expected<record_set, std::string>
-    query(const uenv_label& label) const;
+    // search for all records that match a label.
+    // the partial_name parameter toggles on partial matches on the
+    // label.name field, which is useful for `image ls`  `image find` searches.
+    query(const uenv_label& label, bool partial_name = false) const;
 
     bool contains(const uenv_record&) const;
 


### PR DESCRIPTION
Match partial names, e.g. `uenv image find prgenv` will list uenv that start with `prgenv`.

A tiny update, that touched a bunch of files because of refactoring.