### PR TITLE
remove --list flag in favor of a --format flag

### DIFF
--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -369,7 +369,9 @@ int image_rm([[maybe_unused]] const image_rm_args& args,
             } else if (r->size() > 1) {
                 term::error("the pattern {} matches more than one "
                             "uenv:\n{}use a more specific version",
-                            U, format_record_set_list(*r));
+                            U,
+                            format_record_set_format(
+                                *r, "{name}/{version}:{tag}@{system}%{uarch}"));
                 return 1;
             } else {
                 // check whether there are more than one tag attached to sha

--- a/src/cli/find.cpp
+++ b/src/cli/find.cpp
@@ -31,10 +31,10 @@ void image_find_args::add_cli(CLI::App& cli,
     find_cli->add_flag("--no-header", no_header,
                        "print only the matching records, with no header.");
     find_cli->add_flag("--json", json,
-                       "format output as JSON (incompatible with --list).");
-    find_cli->add_flag("--list", list,
-                       "list the full specs of matching records with no header "
-                       "(incompatible with --json).");
+                       "format output as JSON (incompatible with --format).");
+    find_cli->add_option(
+        "--format", format,
+        "optional format specification (incompatible with --json).");
     find_cli->add_flag("--no-partials", no_partials,
                        "do not match partial names when searching.");
     find_cli->callback(
@@ -54,9 +54,11 @@ int image_find([[maybe_unused]] const image_find_args& args,
         return 1;
     }
 
-    auto format = get_record_set_format(args.no_header, args.json, args.list);
+    auto format =
+        get_record_set_format(args.no_header, args.json, (bool)args.format);
     if (!format) {
         term::error("{}", format.error());
+        return 1;
     }
 
     // find the search term that was provided by the user
@@ -90,7 +92,9 @@ int image_find([[maybe_unused]] const image_find_args& args,
         return 1;
     }
 
-    print_record_set(*result, *format);
+    print_record_set(
+        result.value(), format.value(),
+        format.value() == record_set_format::list ? args.format.value() : "");
 
     return 0;
 }
@@ -139,22 +143,6 @@ std::string image_find_footer() {
     };
 
     return fmt::format("{}", fmt::join(items, "\n"));
-}
-
-util::expected<record_set_format, std::string>
-get_record_set_format(bool no_header, bool json, bool list) {
-    if (json && list) {
-        return util::unexpected(
-            "the --json and --list options are incompatible and can not be "
-            "used at the same time");
-    }
-
-    if (!json && !list) {
-        return no_header ? record_set_format::table_no_header
-                         : record_set_format::table;
-    }
-
-    return json ? record_set_format::json : record_set_format::list;
 }
 
 } // namespace uenv

--- a/src/cli/find.h
+++ b/src/cli/find.h
@@ -11,9 +11,9 @@ namespace uenv {
 
 struct image_find_args {
     std::optional<std::string> uenv_description;
+    std::optional<std::string> format;
     bool no_header = false;
     bool json = false;
-    bool list = false;
     bool no_partials = false;
     bool build = false;
     void add_cli(CLI::App&, global_settings& settings);

--- a/src/cli/ls.cpp
+++ b/src/cli/ls.cpp
@@ -30,9 +30,9 @@ void image_ls_args::add_cli(CLI::App& cli,
                      "print only the matching records, with no header.");
     ls_cli->add_flag("--json", json,
                      "format output as JSON (incompatible with --list).");
-    ls_cli->add_flag("--list", list,
-                     "list the full specs of matching records with no header "
-                     "(incompatible with --json).");
+    ls_cli->add_option(
+        "--format", format,
+        "optional format specification (incompatible with --json).");
     ls_cli->add_flag("--no-partials", no_partials,
                      "do not match partial names when searching.");
     ls_cli->callback(
@@ -49,9 +49,11 @@ int image_ls(const image_ls_args& args, const global_settings& settings) {
         return 1;
     }
 
-    auto format = get_record_set_format(args.no_header, args.json, args.list);
+    auto format =
+        get_record_set_format(args.no_header, args.json, (bool)args.format);
     if (!format) {
         term::error("{}", format.error());
+        return 1;
     }
 
     // open the repo
@@ -84,7 +86,9 @@ int image_ls(const image_ls_args& args, const global_settings& settings) {
         return 1;
     }
 
-    print_record_set(*result, *format);
+    print_record_set(
+        result.value(), format.value(),
+        format.value() == record_set_format::list ? args.format.value() : "");
 
     return 0;
 }

--- a/src/cli/ls.h
+++ b/src/cli/ls.h
@@ -11,9 +11,9 @@ namespace uenv {
 
 struct image_ls_args {
     std::optional<std::string> uenv_description;
+    std::optional<std::string> format;
     bool no_header = false;
     bool json = false;
-    bool list = false;
     bool no_partials = false;
     void add_cli(CLI::App&, global_settings& settings);
 };

--- a/src/uenv/print.h
+++ b/src/uenv/print.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include <uenv/repository.h>
 #include <util/expected.h>
 
@@ -7,15 +9,17 @@ namespace uenv {
 
 enum class record_set_format { table, table_no_header, json, list };
 
-void print_record_set(const record_set& result, record_set_format format);
+void print_record_set(const record_set& result, record_set_format format,
+                      std::string_view fmtstring = "");
 
 std::string format_record_set_table(const record_set& records,
                                     bool no_header = true);
-std::string format_record_set_list(const record_set& records);
 std::string format_record_set_json(const record_set& records);
+std::string format_record_set_format(const record_set& records,
+                                     std::string_view fmtstring);
 
 // a helper for determining the output format based on CLI flags:
-// --no-header, --json and --list
+// --no-header, --json and --format
 util::expected<record_set_format, std::string>
 get_record_set_format(bool no_header, bool json, bool list);
 

--- a/src/uenv/print.h
+++ b/src/uenv/print.h
@@ -9,8 +9,9 @@ namespace uenv {
 
 enum class record_set_format { table, table_no_header, json, list };
 
-void print_record_set(const record_set& result, record_set_format format,
-                      std::string_view fmtstring = "");
+void print_record_set(
+    const record_set& result, record_set_format format,
+    std::string_view fmtstring = "{name}/{version}:{tag}@{system}%{uarch}");
 
 std::string format_record_set_table(const record_set& records,
                                     bool no_header = true);


### PR DESCRIPTION
Instead of
```
uenv image ls --list
```
we now provide a `--format` option that will list matches formatted using the format string, e.g:
```
uenv image ls --format={name}/{version}:{tag}
```

This is applied to the output of both `image ls` and `image find` commands.