### PR TITLE
add missing fields to json output for `image ls` command

### DIFF
--- a/src/uenv/print.cpp
+++ b/src/uenv/print.cpp
@@ -68,6 +68,8 @@ std::string format_record_set_json(const record_set& records) {
     for (auto& r : records) {
         jrecords.push_back(json{
             {"name", r.name},
+            {"version", r.version},
+            {"tag", r.tag},
             {"system", r.system},
             {"uarch", r.uarch},
             {"id", r.id.string()},


### PR DESCRIPTION
With `uenv image ls --json` some useful uenv information are missing. In particular, this PR adds `version` and `tag`.

Before
```json
{
  "date": "2025-12-16 10:06:44",
  "digest": "d159129469c2d7e5bbd0944d1c174f56064c97315bd1228d301fc573eba290e6",
  "id": "d159129469c2d7e5",
  "name": "ascent",
  "size": 5763575808,
  "system": "daint",
  "uarch": "gh200"
}
```

After
```json
{
  "date": "2025-12-16 10:06:44",
  "digest": "d159129469c2d7e5bbd0944d1c174f56064c97315bd1228d301fc573eba290e6",
  "id": "d159129469c2d7e5",
  "name": "ascent",
  "size": 5763575808,
  "system": "daint",
  "tag": "v1",
  "uarch": "gh200",
  "version": "0.9.5"
}
```

This might be useful not only for #130 (even if I know that @bcumming is working on an alternative way to collect information for the bash completion), but also for the final user.