### PR TITLE
Revert "Bump jidicula/clang-format-action from 4.16.0 to 4.18.0"

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Check formatting
-      uses: jidicula/clang-format-action@v4.18.0
+      uses: jidicula/clang-format-action@v4.16.0
       with:
         clang-format-version: '19'


### PR DESCRIPTION
Reverts eth-cscs/uenv#138

Let's deactivate dependabot.