### PR TITLE
mount from NFS squashed file systems

### DIFF
--- a/src/slurm/plugin.cpp
+++ b/src/slurm/plugin.cpp
@@ -255,17 +255,15 @@ int init_post_opt_remote(spank_t sp) {
         return ESPANK_SUCCESS;
     }
 
-    // On NFS filesystems with root_squash, root is mapped to an anonymous
-    // unprivileged user, preventing access to the squashfs file. We
-    // temporarily adopt the job's effective GID so that file opens succeed
-    // for group-readable squashfs files.
-    //
-    // The job GID is set by Slurm to the user's primary group by default,
-    // or to a user-specified group via --gid (Slurm validates membership).
-    // If the squashfs file is owned by a group other than the job GID, the
-    // user should submit their job with --gid=<group>.
-    //
-    // Note: mode 600 squashfs files on root_squash NFS are not supported.
+    // On NFS filesystems with root_squash, root (uid=0) is mapped to an
+    // anonymous unprivileged user, preventing access to the squashfs file
+    // even when the job user owns it. Temporarily adopt the job's effective
+    // UID and GID so that validation and file opens use the user's identity.
+    uid_t job_uid;
+    if (spank_get_item(sp, S_JOB_UID, &job_uid) != ESPANK_SUCCESS) {
+        slurm_error("uenv: failed to get job uid");
+        return -ESPANK_ERROR;
+    }
     gid_t job_gid;
     if (spank_get_item(sp, S_JOB_GID, &job_gid) != ESPANK_SUCCESS) {
         slurm_error("uenv: failed to get job gid");
@@ -276,18 +274,30 @@ int init_post_opt_remote(spank_t sp) {
         slurm_error("uenv: failed to set effective gid: %s", strerror(errno));
         return -ESPANK_ERROR;
     }
-    auto cleanup = util::defer(
+    auto cleanup_gid = util::defer(
         []() noexcept { [[maybe_unused]] int result = setegid(0); });
 
-    // parse and validate the mount descriptions
-    // note that it is very important to carefully validate the mount_list
-    // * check that the squashfs files exist and can be read by the user
-    // * check that the mount points exist
+    if (setegid(job_uid) != 0) {
+        slurm_error("uenv: failed to set effective gid: %s", strerror(errno));
+        return -ESPANK_ERROR;
+    }
+    auto cleanup_uid = util::defer(
+        []() noexcept { [[maybe_unused]] int result = seteuid(0); });
+
+    // parse and validate the mount descriptions, opening each squashfs file.
+    // do_moutn will use /proc/self/fd/N so the kernel does not re-check NFS
+    // permissions under euid=0
     auto mounts = uenv::parse_and_validate_mounts(mount_var.value());
     if (!mounts) {
         slurm_error("%s", mounts.error().c_str());
         return -ESPANK_ERROR;
     }
+    auto cleanup_mounts =
+        util::defer([&mounts]() noexcept { uenv::close_sqfs_fds(*mounts); });
+
+    // unshare_as_root needs CAP_SYS_ADMIN; restore euid=0 now
+    seteuid(0);
+    setegid(0);
 
     if (auto result = uenv::unshare_as_root(); !result) {
         slurm_error("%s", result.error().c_str());

--- a/src/squashfs-mount/squashfs-mount.cpp
+++ b/src/squashfs-mount/squashfs-mount.cpp
@@ -1,3 +1,5 @@
+#include <cerrno>
+#include <cstring>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -16,9 +18,11 @@
 #include <util/envvars.h>
 #include <util/shell.h>
 
+#include <fcntl.h>
 #include <libmount.h>
 #include <sys/mount.h>
 #include <sys/prctl.h>
+#include <unistd.h>
 
 void return_to_user_and_no_new_privs(int uid);
 void unshare_mntns_and_become_root();
@@ -97,14 +101,23 @@ int main(int argc, char** argv, char** envp) {
 
     std::string uenv_mount_list = "";
     if (raw_mounts) {
-        //
-        // validate the mount points
-        //
+        // Drop to real user before validation: the setuid binary starts with
+        // euid=0, which NFS root_squash maps to nobody. Validation and file
+        // opens must run as the real user so NFS sees the correct identity.
+        if (seteuid(uid) != 0) {
+            error_and_exit("seteuid failed: {}", strerror(errno));
+        }
 
         auto mounts = uenv::parse_and_validate_mounts(*raw_mounts);
         if (!mounts) {
             error_and_exit("{}", mounts.error());
         }
+
+        // Re-elevate before privileged mount operations.
+        if (seteuid(0) != 0) {
+            error_and_exit("seteuid failed: {}", strerror(errno));
+        }
+
         uenv_mount_list = fmt::format("{}", fmt::join(mounts.value(), ","));
 
         spdlog::info("uenv_mount_list {}", uenv_mount_list);
@@ -119,6 +132,8 @@ int main(int argc, char** argv, char** envp) {
         if (auto r = uenv::do_mount(mounts.value()); !r) {
             error_and_exit("{}", r.error());
         }
+
+        uenv::close_sqfs_fds(mounts.value());
     } else {
         spdlog::warn("nothing mounted (no --sqfs flag provided)");
     }

--- a/src/uenv/mount.cpp
+++ b/src/uenv/mount.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <filesystem>
-#include <fstream>
 #include <ranges>
 #include <string>
 #include <vector>
@@ -29,10 +29,20 @@
 
 namespace uenv {
 
+void close_sqfs_fds(mount_list& mounts) noexcept {
+    for (auto& entry : mounts) {
+        if (entry.sqfs_fd) {
+            close(*entry.sqfs_fd);
+            entry.sqfs_fd = std::nullopt;
+        }
+    }
+}
+
 // A mount_description has string descriptions of the squashfs file path and
 // mount path taken from parsing a CLI argument or environment variable.
 // Convert this to a mount_pair by converting these to std::filesystem::path,
-// and validating that the squashfs file exists and can be read.
+// validating that the squashfs file exists, and opening an fd that the caller
+// can pass to do_mount (so NFS root_squash does not block the loop mount).
 // The existance of the mount points is not checked, because these need to be
 // checked when mounting.
 util::expected<mount_pair, std::string>
@@ -48,8 +58,8 @@ make_mount_pair(const mount_description& d) {
 
     const auto sqfs = fs::weakly_canonical(fs::path(d.sqfs_path), ec);
     if (ec) {
-        return util::unexpected{fmt::format("invalid squashfs {} ({})",
-                                            d.mount_path, ec.message())};
+        return util::unexpected{
+            fmt::format("invalid squashfs {} ({})", d.sqfs_path, ec.message())};
     }
 
     if (!fs::is_regular_file(sqfs, ec)) {
@@ -57,30 +67,28 @@ make_mount_pair(const mount_description& d) {
             "invalid squashfs {} (is not a regular file)", sqfs.string())};
     }
 
-    // A valid squashfs file contains the magic string "hsqs" in the first 4
-    // bytes.
-    if (std::filesystem::file_size(sqfs) < 4) {
+    // Open the file and verify the squashfs magic bytes ("hsqs").
+    // The fd is kept open and stored in the returned mount_pair so that
+    // do_mount can use /proc/self/fd/N as the loop source, bypassing NFS
+    // permission checks that would otherwise fire under euid=0 with
+    // root_squash.
+    const int fd = open(sqfs.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return util::unexpected{fmt::format("unable to read squashfs {} ({})",
+                                            sqfs.string(), strerror(errno))};
+    }
+
+    std::array<char, 4> magic{};
+    if (read(fd, magic.data(), magic.size()) != 4 ||
+        !(magic[0] == 'h' && magic[1] == 's' && magic[2] == 'q' &&
+          magic[3] == 's')) {
+        close(fd);
         return util::unexpected{fmt::format(
             "unable to read squashfs {} (not a valid squashfs file)",
             sqfs.string())};
     }
-    if (auto file = std::ifstream{sqfs, std::ios::binary}) {
-        std::array<char, 4> magic{};
-        file.read(reinterpret_cast<char*>(magic.data()), magic.size());
 
-        // Compare against little-endian 'hsqs'
-        if (!(magic[0] == 'h' && magic[1] == 's' && magic[2] == 'q' &&
-              magic[3] == 's')) {
-            return util::unexpected{fmt::format(
-                "unable to read squashfs {} (not a valid squashfs file)",
-                sqfs.string())};
-        }
-    } else {
-        return util::unexpected{
-            fmt::format("unable to read squashfs {}", sqfs.string())};
-    }
-
-    return mount_pair{.sqfs = sqfs, .mount = mount};
+    return mount_pair{.sqfs = sqfs, .mount = mount, .sqfs_fd = fd};
 }
 
 util::expected<std::vector<uenv::mount_pair>, std::string>
@@ -156,6 +164,7 @@ validate_mount_descriptions(const std::vector<mount_description>& input) {
     mount_list mounts;
     for (auto desc : input) {
         if (auto mount = uenv::make_mount_pair(desc); !mount) {
+            close_sqfs_fds(mounts);
             return util::unexpected{
                 fmt::format("invalid squashfs mount {}:{} - {}", desc.sqfs_path,
                             desc.mount_path, mount.error())};
@@ -164,7 +173,11 @@ validate_mount_descriptions(const std::vector<mount_description>& input) {
         }
     }
 
-    return validate_mount_list(mounts);
+    auto result = validate_mount_list(mounts);
+    if (!result) {
+        close_sqfs_fds(mounts);
+    }
+    return result;
 }
 
 util::expected<mount_list, std::string>
@@ -183,9 +196,13 @@ do_mount(const std::vector<mount_pair>& mount_entries) {
         return {};
     }
 
-    for (auto& entry : mount_entries) {
+    for (const auto& entry : mount_entries) {
         std::string mount_point = entry.mount;
-        std::string squashfs_file = entry.sqfs;
+        // Use /proc/self/fd/N when a pre-opened fd is available so the kernel
+        // does not re-check NFS permissions under the elevated euid=0.
+        const std::string squashfs_file =
+            entry.sqfs_fd ? fmt::format("/proc/self/fd/{}", *entry.sqfs_fd)
+                          : entry.sqfs.string();
 
         // Check the mount point exists inside the mount loop, because the
         // mount point may have been created inside a previous mount.

--- a/src/uenv/mount.h
+++ b/src/uenv/mount.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -18,6 +19,10 @@ struct mount_description {
 struct mount_pair {
     std::filesystem::path sqfs;
     std::filesystem::path mount;
+    // pre-opened read-only fd for the squashfs file, set before privilege
+    // escalation so NFS root_squash does not remap euid=0 to nobody.
+    // do_mount uses /proc/self/fd/N as the source when this is set.
+    std::optional<int> sqfs_fd = std::nullopt;
 };
 
 // convert a description to a mount_pair that has a validated squashfs path
@@ -34,6 +39,9 @@ using mount_list = std::vector<mount_pair>;
 // }
 util::expected<mount_list, std::string>
 parse_and_validate_mounts(const std::string& description);
+
+/// close any open sqfs_fd entries in the mount list and reset them to nullopt
+void close_sqfs_fds(mount_list& mounts) noexcept;
 
 /// called as root, in slurm-plugin
 util::expected<void, std::string> unshare_as_root();


### PR DESCRIPTION
set euid to the users uid when validating squashfs files.

This fixes ensures that files on nfs mounts with squash root enabled can be accessed
* in the setuid squashfs-mount helper
* in the slurm plugin remote context

both of which run as root, with uid=0, which is squashed to `nobody` when squash root is enabled.

Note that we need to be root to mount, so we open the files as the user, and keep the open file handles for use by root when mounting.