### PR TITLE
replace sha256 implementation with openssl version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,13 +39,15 @@ toml_dep = declare_dependency(
 # zlib: needed for gzip handling in the native OCI registry client
 # Built before curl so override_dependency('zlib') is in place for when curl is configured
 zlib_dep = subproject('zlib', default_options: ['warning_level=0', 'werror=false', 'default_library=static']).get_variable('zlib_dep')
-# openssl: the TLS backend for curl.
+# openssl: the TLS backend for curl, and the SHA-256 implementation used by
+# src/util/sha.cpp - libcrypto's is an order of magnitude faster than a portable
+# C one, which matters because hashing bounds image push and pull.
 # Configured before curl so override_dependency('openssl') is in place for when
-# curl is configured; the returned value is unused, curl consumes it by name.
+# curl is configured; curl consumes it by name, we take libcrypto by hand.
 # Unlike every other subproject this one is not a meson build - it drives
 # OpenSSL's own Configure + make (see subprojects/packagefiles/openssl/), so
 # warning_level/werror/default_library would have nothing to apply to.
-subproject('openssl')
+libcrypto_dep = subproject('openssl').get_variable('libcrypto_dep')
 # Every curl feature is pinned explicitly. Almost all of them default to 'auto',
 # which means they switch on wherever the build host happens to have the dev
 # package installed - the binary we ship would then have runtime dependencies
@@ -146,12 +148,12 @@ lib_uenv = static_library(
         'uenv',
         lib_src,
         include_directories: lib_inc,
-        dependencies: [curl_dep, zlib_dep, libarchive_dep, sqlite3_dep, fmt_dep, spdlog_dep, json_dep, barkeep_dep, toml_dep],
+        dependencies: [curl_dep, zlib_dep, libcrypto_dep, libarchive_dep, sqlite3_dep, fmt_dep, spdlog_dep, json_dep, barkeep_dep, toml_dep],
 )
 
 uenv_dep = declare_dependency(
         link_with: lib_uenv,
-        dependencies: [curl_dep, zlib_dep, libarchive_dep, sqlite3_dep, fmt_dep, spdlog_dep, json_dep, barkeep_dep, libmount_dep, toml_dep],
+        dependencies: [curl_dep, zlib_dep, libcrypto_dep, libarchive_dep, sqlite3_dep, fmt_dep, spdlog_dep, json_dep, barkeep_dep, libmount_dep, toml_dep],
         include_directories: lib_inc
 )
 

--- a/src/util/sha.cpp
+++ b/src/util/sha.cpp
@@ -1,10 +1,12 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 #include <string_view>
 #include <vector>
 
 #include <fmt/format.h>
+#include <openssl/evp.h>
 
 #include <util/sha.h>
 
@@ -20,174 +22,86 @@ bool is_sha_string(std::string_view s) {
     return true;
 }
 
-namespace {
-
-// SHA-256 round constants (first 32 bits of the fractional parts of the cube
-// roots of the first 64 primes), FIPS 180-4 §4.2.2.
-constexpr uint32_t K[64] = {
-    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
-    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
-    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
-    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
-    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
-
-inline uint32_t rotr(uint32_t x, uint32_t n) {
-    return (x >> n) | (x << (32 - n));
-}
-
-} // namespace
-
-// The digest state, held behind sha256_hasher's pimpl. finalize() runs on a
-// copy so the padding it appends never disturbs a hasher that keeps updating.
+// The digest state, held behind sha256_hasher's pimpl: an OpenSSL EVP digest
+// context, so that libcrypto's accelerated SHA-256 does the work - SHA-NI or
+// AVX2 on x86-64, the ARMv8 crypto extensions on aarch64, dispatched at run
+// time. That is worth roughly an order of magnitude over a portable C
+// implementation, and hashing bounds both `uenv image push` (which digests the
+// whole squashfs before uploading it) and `uenv image pull` (which digests the
+// download as it streams).
+//
+// None of the failure paths below are reachable short of allocation failure:
+// OpenSSL is configured no-module/no-dso, so the default provider that supplies
+// SHA-256 is compiled into libcrypto and cannot fail to load. They throw
+// because the public API has no error channel, and a wrong digest would be far
+// worse than an exception.
 class sha256_impl {
   public:
+    sha256_impl();
+    ~sha256_impl();
+    sha256_impl(const sha256_impl&) = delete;
+    sha256_impl& operator=(const sha256_impl&) = delete;
+
     void init();
-    void update(const uint8_t* p, std::size_t len);
+    void update(const unsigned char* p, std::size_t len);
     sha256 finalize() const;
 
   private:
-    void process_block(const uint8_t block[64]);
-
-    uint32_t state[8];
-    uint64_t bitlen;
-    uint8_t buffer[64];
-    std::size_t buffer_len;
+    EVP_MD_CTX* ctx_;
 };
 
+sha256_impl::sha256_impl() : ctx_(EVP_MD_CTX_new()) {
+    if (ctx_ == nullptr) {
+        throw std::runtime_error("unable to allocate a SHA-256 digest context");
+    }
+    init();
+}
+
+sha256_impl::~sha256_impl() {
+    EVP_MD_CTX_free(ctx_);
+}
+
 void sha256_impl::init() {
-    // initial hash values: fractional parts of the square roots of the first 8
-    // primes, FIPS 180-4 §5.3.3.
-    state[0] = 0x6a09e667;
-    state[1] = 0xbb67ae85;
-    state[2] = 0x3c6ef372;
-    state[3] = 0xa54ff53a;
-    state[4] = 0x510e527f;
-    state[5] = 0x9b05688c;
-    state[6] = 0x1f83d9ab;
-    state[7] = 0x5be0cd19;
-    bitlen = 0;
-    buffer_len = 0;
+    if (EVP_DigestInit_ex(ctx_, EVP_sha256(), nullptr) != 1) {
+        throw std::runtime_error("unable to initialise a SHA-256 digest");
+    }
 }
 
-void sha256_impl::process_block(const uint8_t block[64]) {
-    uint32_t w[64];
-    for (int i = 0; i < 16; ++i) {
-        w[i] = (static_cast<uint32_t>(block[i * 4]) << 24) |
-               (static_cast<uint32_t>(block[i * 4 + 1]) << 16) |
-               (static_cast<uint32_t>(block[i * 4 + 2]) << 8) |
-               (static_cast<uint32_t>(block[i * 4 + 3]));
-    }
-    for (int i = 16; i < 64; ++i) {
-        uint32_t s0 =
-            rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
-        uint32_t s1 =
-            rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
-        w[i] = w[i - 16] + s0 + w[i - 7] + s1;
-    }
-
-    uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
-    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
-
-    for (int i = 0; i < 64; ++i) {
-        uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
-        uint32_t ch = (e & f) ^ (~e & g);
-        uint32_t temp1 = h + S1 + ch + K[i] + w[i];
-        uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
-        uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
-        uint32_t temp2 = S0 + maj;
-
-        h = g;
-        g = f;
-        f = e;
-        e = d + temp1;
-        d = c;
-        c = b;
-        b = a;
-        a = temp1 + temp2;
-    }
-
-    state[0] += a;
-    state[1] += b;
-    state[2] += c;
-    state[3] += d;
-    state[4] += e;
-    state[5] += f;
-    state[6] += g;
-    state[7] += h;
-}
-
-void sha256_impl::update(const uint8_t* p, std::size_t len) {
-    bitlen += static_cast<uint64_t>(len) * 8;
-
-    // top up a partially-filled buffer first
-    if (buffer_len > 0) {
-        std::size_t need = 64 - buffer_len;
-        std::size_t take = len < need ? len : need;
-        std::memcpy(buffer + buffer_len, p, take);
-        buffer_len += take;
-        p += take;
-        len -= take;
-        if (buffer_len == 64) {
-            process_block(buffer);
-            buffer_len = 0;
-        }
-    }
-
-    // process whole blocks straight from the input
-    while (len >= 64) {
-        process_block(p);
-        p += 64;
-        len -= 64;
-    }
-
-    // stash the remainder
-    if (len > 0) {
-        std::memcpy(buffer + buffer_len, p, len);
-        buffer_len += len;
+void sha256_impl::update(const unsigned char* p, std::size_t len) {
+    if (EVP_DigestUpdate(ctx_, p, len) != 1) {
+        throw std::runtime_error("unable to update a SHA-256 digest");
     }
 }
 
 sha256 sha256_impl::finalize() const {
-    // work on a copy: the padding below must not disturb a hasher that keeps
-    // being updated after finalize().
-    sha256_impl s = *this;
-    uint64_t final_bitlen = s.bitlen;
-
-    // append the 0x80 padding byte, then zeros up to a 56-byte boundary, then
-    // the 64-bit big-endian length.
-    uint8_t pad = 0x80;
-    s.update(&pad, 1);
-
-    uint8_t zero = 0x00;
-    while (s.buffer_len != 56) {
-        s.update(&zero, 1);
+    // EVP_DigestFinal_ex() appends the padding and consumes the context it is
+    // given, so work on a copy: a hasher may keep being updated after
+    // finalize().
+    EVP_MD_CTX* copy = EVP_MD_CTX_new();
+    if (copy == nullptr) {
+        throw std::runtime_error("unable to allocate a SHA-256 digest context");
     }
 
-    uint8_t lenbytes[8];
-    for (int i = 0; i < 8; ++i) {
-        lenbytes[i] = static_cast<uint8_t>(final_bitlen >> (56 - i * 8));
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int len = 0;
+    const bool ok = EVP_MD_CTX_copy_ex(copy, ctx_) == 1 &&
+                    EVP_DigestFinal_ex(copy, digest, &len) == 1;
+    EVP_MD_CTX_free(copy);
+    if (!ok || len != 32) {
+        throw std::runtime_error("unable to finalize a SHA-256 digest");
     }
-    s.update(lenbytes, 8); // fills the block; update() flushes it
 
-    // render the eight state words as 64 lowercase-hex characters (each word is
-    // big-endian, so {:08x} reproduces the canonical byte order).
+    // render the 32 digest bytes as 64 lowercase-hex characters.
     std::string hex;
     hex.reserve(64);
-    for (int i = 0; i < 8; ++i) {
-        fmt::format_to(std::back_inserter(hex), "{:08x}", s.state[i]);
+    for (unsigned int i = 0; i < len; ++i) {
+        fmt::format_to(std::back_inserter(hex), "{:02x}", digest[i]);
     }
     // trusted by construction: hex is exactly 64 lowercase-hex characters.
     return sha256::parse(hex).value();
 }
 
 sha256_hasher::sha256_hasher() : impl_(std::make_unique<sha256_impl>()) {
-    impl_->init();
 }
 
 sha256_hasher::~sha256_hasher() = default;
@@ -195,7 +109,8 @@ sha256_hasher::sha256_hasher(sha256_hasher&&) noexcept = default;
 sha256_hasher& sha256_hasher::operator=(sha256_hasher&&) noexcept = default;
 
 void sha256_hasher::update(std::span<const std::byte> data) {
-    impl_->update(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+    impl_->update(reinterpret_cast<const unsigned char*>(data.data()),
+                  data.size());
 }
 
 void sha256_hasher::reset() {

--- a/test/unit/sha.cpp
+++ b/test/unit/sha.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_all.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
@@ -8,6 +9,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -172,6 +174,26 @@ TEST_CASE("sha256 reset restarts the hasher", "[sha]") {
     REQUIRE(h.finalize() == util::sha256_string("abc"));
 }
 
+TEST_CASE("sha256_hasher is movable", "[sha]") {
+    SECTION("move construction carries the state") {
+        util::sha256_hasher h;
+        h.update(as_bytes("abc"));
+        util::sha256_hasher moved{std::move(h)};
+        moved.update(as_bytes("def"));
+        REQUIRE(moved.finalize() == util::sha256_string("abcdef"));
+    }
+
+    SECTION("move assignment carries the state") {
+        util::sha256_hasher h;
+        h.update(as_bytes("abc"));
+        util::sha256_hasher other;
+        other.update(as_bytes("discarded"));
+        other = std::move(h);
+        other.update(as_bytes("def"));
+        REQUIRE(other.finalize() == util::sha256_string("abcdef"));
+    }
+}
+
 namespace {
 // write `content` to a fresh file in a temporary directory, and return its
 // path.
@@ -247,4 +269,28 @@ TEST_CASE("sha256_file", "[sha]") {
         REQUIRE(d);
         REQUIRE(seen.empty());
     }
+}
+
+// hidden (the leading dot in the tag): hashing 1 GiB is far too slow to belong
+// in the default run. Run it explicitly with `./test/unit "[sha-bench]"` to
+// measure the digest throughput, which is what bounds `uenv image push` and
+// `uenv image pull` on multi-GB squashfs images.
+TEST_CASE("sha256 throughput", "[.sha-bench]") {
+    constexpr std::size_t chunk = 1u << 20;
+    constexpr std::size_t chunks = 1024;
+
+    std::vector<std::byte> buf(chunk, std::byte{0x5a});
+    util::sha256_hasher h;
+
+    const auto start = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < chunks; ++i) {
+        h.update(std::span<const std::byte>{buf});
+    }
+    const auto digest = h.finalize();
+    const auto stop = std::chrono::steady_clock::now();
+
+    const double seconds = std::chrono::duration<double>(stop - start).count();
+    const double mb = static_cast<double>(chunk * chunks) / (1024.0 * 1024.0);
+    WARN(fmt::format("sha256: {:.0f} MiB in {:.3f} s = {:.0f} MiB/s ({})", mb,
+                     seconds, mb / seconds, digest));
 }


### PR DESCRIPTION
The vanilla C implementation of sha256 is slow: no specialised instructions.

it is ~10x slower than the hardware-optimised implementation provided by OpenSSL.
e.g. on a zen4 AMD CPU:
* The scalar loop runs at roughly 250 MB/s per core.
* `openssl speed -evp sha256` reports 2.6 GB/s

The fix is simple: replace the PIMPLed sha256 implementation with calls out to `EVP_Digest*`.

The result on Daint:


oras:
```
pulling f2bbdc4192155cf6  42.85% ━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━ 3258/7603 (664.61 MB/s)
```
hand rolled sha256
```
pulling f2bbdc4192155cf6   4.41% ━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━  335/7603 (56.75 MB/s)
```
openssl call out
```
pulling f2bbdc4192155cf6  29.00% ━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━ 2205/7603 (611.72 MB/s)
```