### PR TITLE
consistent image hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ install
 
 build
 pyenv
+
+task.md

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -148,9 +148,9 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     std::optional<std::string> manifest_body;
     if (!from_label) {
         auto created = oci::rfc3339(*util::file_creation_date(sqfs->sqfs));
-        auto m = oci::make_squashfs_manifest(oci::digest::sha256(sqfs->hash),
-                                             fs::file_size(sqfs->sqfs),
-                                             created);
+        auto m =
+            oci::make_squashfs_manifest(oci::digest::sha256(sqfs->hash),
+                                        fs::file_size(sqfs->sqfs), created);
         manifest_body = oci::serialize_manifest(m);
         spdlog::debug("image_add: creating manifest {}", *manifest_body);
 
@@ -193,8 +193,9 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     // If a sqfs file is already in repo then it must be added using:
     //   uenv image add <new-label> <existing-label>
     if (source_in_repo && !from_label) {
-        term::error("image_add: Trying to add a squashfs file which is already "
-                    "in the repository. Add using a label instead of squashfs.");
+        term::error(
+            "image_add: Trying to add a squashfs file which is already "
+            "in the repository. Add using a label instead of squashfs.");
         return 1;
     }
 
@@ -212,20 +213,20 @@ int image_add(const image_add_args& args, const global_settings& settings) {
 
         if (existing_hash && !from_label) {
             term::error("a uenv with the same sha {} is already in the repo",
-                       image_hash);
+                        image_hash);
             return 1;
         }
     }
 
     // If copying the squashfs file into the repository
-    // Create the path <repo>/images/<hash> and populate with meta data, manifest
-    // and the image iteself.
+    // Create the path <repo>/images/<hash> and populate with meta data,
+    // manifest and the image iteself.
     if (!source_in_repo) {
         // create the path inside the repo
         std::error_code ec;
         // if the path exists, delete it: it was probably caused by an aborted
-        // `image add` or `image pull` command that did not complete the download
-        // and database update.
+        // `image add` or `image pull` command that did not complete the
+        // download and database update.
         if (fs::exists(uenv_paths.store)) {
             spdlog::debug("image_add: remove the target path {} before copying",
                           uenv_paths.store.string());
@@ -258,10 +259,12 @@ int image_add(const image_add_args& args, const global_settings& settings) {
 
         // copy or move the squashfs file
         if (!args.move) {
-            spdlog::debug("image_add: copying {} to {}", sqfs->sqfs, uenv_paths.squashfs);
+            spdlog::debug("image_add: copying {} to {}", sqfs->sqfs,
+                          uenv_paths.squashfs);
             // record the source modification time so that it can be preserved
-            // on the copy: fs::copy_file stamps the destination with the current
-            // time, whereas fs::rename (the move case) keeps the source time.
+            // on the copy: fs::copy_file stamps the destination with the
+            // current time, whereas fs::rename (the move case) keeps the source
+            // time.
             std::error_code tec;
             const auto src_time = fs::last_write_time(sqfs->sqfs, tec);
             fs::copy_file(sqfs->sqfs, uenv_paths.squashfs, ec);
@@ -283,7 +286,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                     uenv_paths.squashfs.string(), tec.message());
             }
         } else {
-            spdlog::debug("image_add: moving {} to {}", sqfs->sqfs, uenv_paths.squashfs);
+            spdlog::debug("image_add: moving {} to {}", sqfs->sqfs,
+                          uenv_paths.squashfs);
             fs::rename(sqfs->sqfs, uenv_paths.squashfs, ec);
             if (ec) {
                 spdlog::error("unable to move squashfs image {} to {}: {}",

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -1,5 +1,6 @@
 // vim: ts=4 sts=4 sw=4 et
 
+#include <fstream>
 #include <memory>
 #include <string>
 
@@ -8,12 +9,15 @@
 #include <fmt/std.h>
 #include <spdlog/spdlog.h>
 
+#include <oci/digest.h>
+#include <oci/manifest.h>
 #include <uenv/env.h>
 #include <uenv/parse.h>
 #include <uenv/print.h>
 #include <uenv/repository.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/sha.h>
 #include <util/subprocess.h>
 
 #include "add_remove.h"
@@ -131,6 +135,27 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                  *label);
 
     //
+    // if this is a newly added squashfs file (not a retag of an existing
+    // repo entry), mint the manifest that identifies it: its sha256 becomes
+    // the <hash> used to store and index it, and it is persisted alongside
+    // the image so that a later `uenv image push` can reuse it verbatim
+    // instead of minting a new one. `created` is derived from the squashfs
+    // file's own creation date, rather than the current time, so that
+    // re-adding identical squashfs content always mints the same manifest
+    // (and hence hash), preserving the existing_hash dedup check below.
+    //
+    sha256 image_hash = sqfs->hash;
+    std::optional<std::string> manifest_body;
+    if (!from_label) {
+        auto created = oci::rfc3339(*util::file_creation_date(sqfs->sqfs));
+        auto m = oci::make_squashfs_manifest(oci::digest::sha256(sqfs->hash),
+                                             fs::file_size(sqfs->sqfs),
+                                             created);
+        manifest_body = oci::serialize_manifest(m);
+        image_hash = util::sha256_string(*manifest_body);
+    }
+
+    //
     // Open the repository
     //
     auto store = uenv::concretise_user_repo(settings.config);
@@ -165,7 +190,7 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     //
     bool existing_hash = false;
     {
-        uenv_label hash_label{sqfs->hash.string()};
+        uenv_label hash_label{image_hash.string()};
         auto results = store->query(hash_label);
         if (!results) {
             term::error(
@@ -176,13 +201,13 @@ int image_add(const image_add_args& args, const global_settings& settings) {
 
         if (existing_hash) {
             spdlog::warn("a uenv with the same sha {} is already in the repo",
-                         sqfs->hash);
+                         image_hash);
             term::warn("a uenv with the same sha {} is already in the repo",
-                       sqfs->hash);
+                       image_hash);
         }
     }
 
-    const auto uenv_paths = store->uenv_paths(sqfs->hash);
+    const auto uenv_paths = store->uenv_paths(image_hash);
     uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
 
     bool source_in_repo = util::is_child(sqfs->sqfs, uenv_paths.root);
@@ -259,6 +284,20 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                 return 1;
             }
         }
+
+        //
+        // persist the manifest alongside the image
+        //
+        if (manifest_body) {
+            std::ofstream mfid(uenv_paths.manifest);
+            mfid << *manifest_body;
+            if (!mfid) {
+                spdlog::error("unable to write manifest to {}",
+                              uenv_paths.manifest.string());
+                term::error("unable to add the uenv");
+                return 1;
+            }
+        }
     }
 
     //
@@ -277,15 +316,15 @@ int image_add(const image_add_args& args, const global_settings& settings) {
         *label->tag,
         date,
         fs::file_size(uenv_paths.squashfs),
-        sqfs->hash,
-        uenv_id::parse(sqfs->hash.string().substr(0, 16)).value(),
+        image_hash,
+        uenv_id::parse(image_hash.string().substr(0, 16)).value(),
     };
     if (auto result = store->add(r); !result) {
         spdlog::error("image_add: {}", result.error());
         term::error("unable to add the uenv");
         return 1;
     }
-    term::msg("the uenv {} with sha {} was added to {}", r, sqfs->hash,
+    term::msg("the uenv {} with sha {} was added to {}", r, image_hash,
               store->path()->string());
 
     return 0;

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -95,7 +95,7 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     }
 
     // derive the full description of the source uenv.
-    auto env = resolve_uenv(source, settings.config.repos);
+    const auto env = resolve_uenv(source, settings.config.repos);
     if (!env) {
         term::error("{}", env.error());
         return 1;
@@ -152,21 +152,22 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                                              fs::file_size(sqfs->sqfs),
                                              created);
         manifest_body = oci::serialize_manifest(m);
+        spdlog::debug("image_add: creating manifest {}", *manifest_body);
+
         image_hash = util::sha256_string(*manifest_body);
+        spdlog::debug("image_add: manifest hash {}", image_hash);
     }
 
-    //
     // Open the repository
-    //
     auto store = uenv::concretise_user_repo(settings.config);
     if (!store) {
         term::error("unable to open repo: {}", store.error());
         return 1;
     }
 
-    //
-    // check whether the label also exists
-    //
+    spdlog::debug("image_add: using repo {}", store->path());
+
+    // check whether the label already exists in the repo
     bool existing_label = false;
     {
         auto results = store->query(*label);
@@ -184,11 +185,21 @@ int image_add(const image_add_args& args, const global_settings& settings) {
         }
     }
 
-    //
+    // check whether the hash already exists in the repo
+
+    const auto uenv_paths = store->uenv_paths(image_hash);
+    const bool source_in_repo = util::is_child(sqfs->sqfs, uenv_paths.root);
+
+    // If a sqfs file is already in repo then it must be added using:
+    //   uenv image add <new-label> <existing-label>
+    if (source_in_repo && !from_label) {
+        term::error("image_add: Trying to add a squashfs file which is already "
+                    "in the repository. Add using a label instead of squashfs.");
+        return 1;
+    }
+
     // check whether repository already contains an image with the same
     // hash
-    //
-    bool existing_hash = false;
     {
         uenv_label hash_label{image_hash.string()};
         auto results = store->query(hash_label);
@@ -197,37 +208,24 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                 "image_add: internal error search repository for {}\n  {}",
                 *label, results.error());
         }
-        existing_hash = !results->empty();
+        const auto existing_hash = !results->empty();
 
-        if (existing_hash) {
-            spdlog::warn("a uenv with the same sha {} is already in the repo",
-                         image_hash);
-            term::warn("a uenv with the same sha {} is already in the repo",
+        if (existing_hash && !from_label) {
+            term::error("a uenv with the same sha {} is already in the repo",
                        image_hash);
+            return 1;
         }
     }
 
-    const auto uenv_paths = store->uenv_paths(image_hash);
-    uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
-
-    bool source_in_repo = util::is_child(sqfs->sqfs, uenv_paths.root);
-
-    // If an sqfs file is already in repo, and it was pulled from a repository
-    // then there is a digest mismatch. Do not try to add this image
-    // Such images should be retaged with the command:
-    // uenv image add <new-label> <existing-label>
-    if (source_in_repo && !existing_hash) {
-        term::error("image_add: Trying to add a squashfs file which is already "
-                    "in the repository, but the hashes do not match");
-        return 1;
-    }
-
+    // If copying the squashfs file into the repository
+    // Create the path <repo>/images/<hash> and populate with meta data, manifest
+    // and the image iteself.
     if (!source_in_repo) {
-        //
         // create the path inside the repo
-        //
         std::error_code ec;
-        // if the path exists, delete it, as it might contain a partial download
+        // if the path exists, delete it: it was probably caused by an aborted
+        // `image add` or `image pull` command that did not complete the download
+        // and database update.
         if (fs::exists(uenv_paths.store)) {
             spdlog::debug("image_add: remove the target path {} before copying",
                           uenv_paths.store.string());
@@ -242,9 +240,9 @@ int image_add(const image_add_args& args, const global_settings& settings) {
             return 1;
         }
 
-        //
+        spdlog::debug("image_add: repo path {}", uenv_paths.store);
+
         // copy the meta data into the repo
-        //
         if (sqfs->meta) {
             fs::copy_options options{};
             options |= fs::copy_options::recursive;
@@ -255,10 +253,12 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                 term::error("unable to add the uenv");
                 return 1;
             }
+            spdlog::debug("image_add: added meta path {}", sqfs->meta.value());
         }
 
-        // copy or move the
+        // copy or move the squashfs file
         if (!args.move) {
+            spdlog::debug("image_add: copying {} to {}", sqfs->sqfs, uenv_paths.squashfs);
             fs::copy_file(sqfs->sqfs, uenv_paths.squashfs, ec);
             if (ec) {
                 spdlog::error("unable to copy squashfs image {} to {}: {}",
@@ -268,6 +268,7 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                 return 1;
             }
         } else {
+            spdlog::debug("image_add: moving {} to {}", sqfs->sqfs, uenv_paths.squashfs);
             fs::rename(sqfs->sqfs, uenv_paths.squashfs, ec);
             if (ec) {
                 spdlog::error("unable to move squashfs image {} to {}: {}",
@@ -285,9 +286,7 @@ int image_add(const image_add_args& args, const global_settings& settings) {
             }
         }
 
-        //
-        // persist the manifest alongside the image
-        //
+        // add the manifest alongside the image
         if (manifest_body) {
             std::ofstream mfid(uenv_paths.manifest);
             mfid << *manifest_body;
@@ -300,9 +299,8 @@ int image_add(const image_add_args& args, const global_settings& settings) {
         }
     }
 
-    //
-    // add the uenv to the database
-    //
+    // add the label to the database
+    const uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
     if (!date.validate()) {
         spdlog::error("the date {} is invalid", date);
         term::error("unable to add the uenv");

--- a/src/cli/add_remove.cpp
+++ b/src/cli/add_remove.cpp
@@ -259,6 +259,11 @@ int image_add(const image_add_args& args, const global_settings& settings) {
         // copy or move the squashfs file
         if (!args.move) {
             spdlog::debug("image_add: copying {} to {}", sqfs->sqfs, uenv_paths.squashfs);
+            // record the source modification time so that it can be preserved
+            // on the copy: fs::copy_file stamps the destination with the current
+            // time, whereas fs::rename (the move case) keeps the source time.
+            std::error_code tec;
+            const auto src_time = fs::last_write_time(sqfs->sqfs, tec);
             fs::copy_file(sqfs->sqfs, uenv_paths.squashfs, ec);
             if (ec) {
                 spdlog::error("unable to copy squashfs image {} to {}: {}",
@@ -266,6 +271,16 @@ int image_add(const image_add_args& args, const global_settings& settings) {
                               ec.message());
                 term::error("unable to add the uenv");
                 return 1;
+            }
+            // preserve the source modification time on the copy so that the
+            // creation date recorded in the repository matches the source.
+            if (!tec) {
+                fs::last_write_time(uenv_paths.squashfs, src_time, tec);
+            }
+            if (tec) {
+                spdlog::warn(
+                    "image_add: unable to preserve modification time on {}: {}",
+                    uenv_paths.squashfs.string(), tec.message());
             }
         } else {
             spdlog::debug("image_add: moving {} to {}", sqfs->sqfs, uenv_paths.squashfs);
@@ -300,7 +315,10 @@ int image_add(const image_add_args& args, const global_settings& settings) {
     }
 
     // add the label to the database
-    const uenv::uenv_date date{*util::file_creation_date(sqfs->sqfs)};
+    // read the creation date from the image in its final destination in the
+    // repository: in the --move case the source path no longer exists, and in
+    // both cases the in-repo copy is the authoritative file.
+    const uenv::uenv_date date{*util::file_creation_date(uenv_paths.squashfs)};
     if (!date.validate()) {
         spdlog::error("the date {} is invalid", date);
         term::error("unable to add the uenv");

--- a/src/cli/pull.cpp
+++ b/src/cli/pull.cpp
@@ -2,6 +2,7 @@
 
 #include <csignal>
 #include <filesystem>
+#include <fstream>
 #include <string>
 
 #include <fmt/core.h>
@@ -274,6 +275,19 @@ int image_pull(const image_pull_args& args, const global_settings& settings) {
                     }
                     term::error("unable to pull uenv.\n{}", result.error());
                     return 1;
+                }
+            }
+
+            // persist the manifest alongside the image, so that the hash
+            // this image is stored under locally (record.sha, the manifest
+            // digest reported by the registry) is explained by a manifest on
+            // disk, same as a locally-added image.
+            {
+                std::ofstream mfid(paths.manifest);
+                mfid << response->body;
+                if (!mfid) {
+                    spdlog::warn("unable to write manifest to {}",
+                                 paths.manifest.string());
                 }
             }
         } catch (util::signal_exception& e) {

--- a/src/cli/push.cpp
+++ b/src/cli/push.cpp
@@ -150,14 +150,10 @@ int image_push([[maybe_unused]] const image_push_args& args,
     if (env->record) {
         // env->record->sha is the *manifest* digest (or, for a legacy record
         // predating manifest.json, the squashfs file's own hash - the two
-        // coincide only in that legacy case). manifest.json, when present, is
-        // a sibling of store.squashfs inside the record's
-        // store/images/<hash>/ directory; its layer entry gives the true
-        // squashfs layer digest.
+        // coincide only in that legacy case). manifest.json, when present,
+        // gives the true squashfs layer digest via its layer entry.
         util::sha256 layer_hash = env->record->sha;
-        const auto manifest_path =
-            env->sqfs_path.parent_path() / "manifest.json";
-        if (auto read = util::read_file(manifest_path); read) {
+        if (auto read = util::read_file(env->manifest_path.value()); read) {
             auto body = std::move(*read);
             if (auto parsed = oci::parse_manifest(body)) {
                 const oci::manifest_layer* layer =

--- a/src/cli/push.cpp
+++ b/src/cli/push.cpp
@@ -1,7 +1,9 @@
 // vim: ts=4 sts=4 sw=4 et
 
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unistd.h>
 
@@ -17,6 +19,7 @@
 #include <oci/manifest.h>
 #include <oci/push.h>
 #include <site/site.h>
+#include <uenv/env.h>
 #include <uenv/parse.h>
 #include <uenv/print.h>
 #include <uenv/repository.h>
@@ -24,6 +27,7 @@
 #include <util/curl.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/sha.h>
 #include <util/signal.h>
 
 #include "help.h"
@@ -125,26 +129,90 @@ int image_push([[maybe_unused]] const image_push_args& args,
         term::msg("the destination already exists and will be overwritten");
     }
 
-    // validate the source squashfs file. This hashes the whole image, which
-    // takes minutes for a multi-GB uenv, so show a progress bar for it. The bar
-    // is created on the first callback, once the image size is known.
-    std::unique_ptr<uenv::transfer_bar> prepare_bar;
-    auto sqfs = uenv::validate_squashfs_image(
-        args.source,
-        [&prepare_bar, &args](std::uint64_t done, std::uint64_t total) {
-            if (!prepare_bar) {
-                prepare_bar = uenv::make_transfer_bar(
-                    total, fmt::format("validating {}",
-                                       std::filesystem::path{args.source}
-                                           .filename()
-                                           .string()));
+    // resolve the source: either a squashfs file path, or a label already in
+    // the local repository. When it resolves to an existing repository
+    // record, its manifest.json (if the record has one, i.e. it was added
+    // after uenv started persisting manifests) is reused verbatim below,
+    // rather than minting a fresh manifest.
+    uenv_description source;
+    if (const auto parse = parse_uenv_description(args.source); !parse) {
+        term::error("invalid uenv specification: {}", parse.error().message());
+        return 1;
+    } else {
+        source = parse.value();
+    }
+    auto env = resolve_uenv(source, settings.config.repos);
+    if (!env) {
+        term::error("{}", env.error());
+        return 1;
+    }
+
+    std::optional<std::string> existing_manifest_body;
+    util::expected<squashfs_image, std::string> sqfs;
+    if (env->record) {
+        // env->record->sha is the *manifest* digest (or, for a legacy record
+        // predating manifest.json, the squashfs file's own hash - the two
+        // coincide only in that legacy case). manifest.json, when present, is
+        // a sibling of store.squashfs inside the record's
+        // store/images/<hash>/ directory; its layer entry gives the true
+        // squashfs layer digest.
+        util::sha256 layer_hash = env->record->sha;
+        const auto manifest_path =
+            env->sqfs_path.parent_path() / "manifest.json";
+        if (std::filesystem::exists(manifest_path)) {
+            std::ifstream mfid(manifest_path);
+            std::ostringstream ss;
+            ss << mfid.rdbuf();
+            auto body = ss.str();
+            if (auto parsed = oci::parse_manifest(body)) {
+                const oci::manifest_layer* layer =
+                    parsed->find_layer_by_title("store.squashfs");
+                if (!layer && parsed->layers.size() == 1) {
+                    layer = &parsed->layers[0];
+                }
+                if (layer) {
+                    if (auto h = util::sha256::parse(layer->digest.hex())) {
+                        layer_hash = *h;
+                        existing_manifest_body = std::move(body);
+                    } else {
+                        spdlog::warn("manifest.json for {} has an invalid "
+                                     "layer digest; ignoring it",
+                                     env->sqfs_path.string());
+                    }
+                } else {
+                    spdlog::warn(
+                        "manifest.json for {} has no squashfs layer; "
+                        "ignoring it",
+                        env->sqfs_path.string());
+                }
+            } else {
+                spdlog::warn("unable to parse manifest.json for {}",
+                             env->sqfs_path.string());
             }
-            prepare_bar->update(done);
-        });
-    // stop the bar before anything else is printed, so that an error message
-    // does not land on the bar's line.
-    if (prepare_bar) {
-        prepare_bar->finish();
+        }
+        sqfs = squashfs_image{env->sqfs_path, env->meta_path, layer_hash};
+    } else {
+        // validate the source squashfs file. This hashes the whole image,
+        // which takes minutes for a multi-GB uenv, so show a progress bar
+        // for it. The bar is created on the first callback, once the image
+        // size is known.
+        std::unique_ptr<uenv::transfer_bar> prepare_bar;
+        sqfs = uenv::validate_squashfs_image(
+            env->sqfs_path.string(),
+            [&prepare_bar, &env](std::uint64_t done, std::uint64_t total) {
+                if (!prepare_bar) {
+                    prepare_bar = uenv::make_transfer_bar(
+                        total,
+                        fmt::format("validating {}",
+                                    env->sqfs_path.filename().string()));
+                }
+                prepare_bar->update(done);
+            });
+        // stop the bar before anything else is printed, so that an error
+        // message does not land on the bar's line.
+        if (prepare_bar) {
+            prepare_bar->finish();
+        }
     }
     if (!sqfs) {
         term::error("invalid squashfs file {}: {}", args.source, sqfs.error());
@@ -188,11 +256,15 @@ int image_push([[maybe_unused]] const image_push_args& args,
         auto progress = [&bar](std::uint64_t now, std::uint64_t) {
             bar->update(now);
         };
-        // the image was hashed by validate_squashfs_image; pass that digest in
-        // rather than reading the whole file a second time.
+        // the image was hashed by validate_squashfs_image (or already known
+        // from the resolved repo record); pass that digest in rather than
+        // reading the whole file a second time. When a manifest.json was
+        // found alongside a resolved repo record, reuse it verbatim instead
+        // of minting a fresh one, so the pushed digest matches the hash the
+        // image is already stored under locally.
         auto push_result = oci::push_squashfs(
             *client, sqfs->sqfs, oci::reference::tag(*push_tag),
-            oci::digest::sha256(sqfs->hash), progress);
+            oci::digest::sha256(sqfs->hash), progress, existing_manifest_body);
         // fill the bar on success, which also covers the case where the
         // registry already had the blob and no upload happened.
         if (push_result) {

--- a/src/cli/push.cpp
+++ b/src/cli/push.cpp
@@ -1,9 +1,7 @@
 // vim: ts=4 sts=4 sw=4 et
 
 #include <filesystem>
-#include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unistd.h>
 
@@ -159,11 +157,8 @@ int image_push([[maybe_unused]] const image_push_args& args,
         util::sha256 layer_hash = env->record->sha;
         const auto manifest_path =
             env->sqfs_path.parent_path() / "manifest.json";
-        if (std::filesystem::exists(manifest_path)) {
-            std::ifstream mfid(manifest_path);
-            std::ostringstream ss;
-            ss << mfid.rdbuf();
-            auto body = ss.str();
+        if (auto read = util::read_file(manifest_path); read) {
+            auto body = std::move(*read);
             if (auto parsed = oci::parse_manifest(body)) {
                 const oci::manifest_layer* layer =
                     parsed->find_layer_by_title("store.squashfs");

--- a/src/cli/push.cpp
+++ b/src/cli/push.cpp
@@ -171,10 +171,9 @@ int image_push([[maybe_unused]] const image_push_args& args,
                                      env->sqfs_path.string());
                     }
                 } else {
-                    spdlog::warn(
-                        "manifest.json for {} has no squashfs layer; "
-                        "ignoring it",
-                        env->sqfs_path.string());
+                    spdlog::warn("manifest.json for {} has no squashfs layer; "
+                                 "ignoring it",
+                                 env->sqfs_path.string());
                 }
             } else {
                 spdlog::warn("unable to parse manifest.json for {}",
@@ -193,9 +192,8 @@ int image_push([[maybe_unused]] const image_push_args& args,
             [&prepare_bar, &env](std::uint64_t done, std::uint64_t total) {
                 if (!prepare_bar) {
                     prepare_bar = uenv::make_transfer_bar(
-                        total,
-                        fmt::format("validating {}",
-                                    env->sqfs_path.filename().string()));
+                        total, fmt::format("validating {}",
+                                           env->sqfs_path.filename().string()));
                 }
                 prepare_bar->update(done);
             });

--- a/src/oci/manifest.cpp
+++ b/src/oci/manifest.cpp
@@ -1,3 +1,4 @@
+#include <ctime>
 #include <optional>
 #include <string>
 
@@ -10,6 +11,32 @@
 #include <oci/util.h>
 
 namespace oci {
+
+std::string rfc3339(std::tm tm) {
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return buf;
+}
+
+std::string rfc3339_now() {
+    std::time_t t = std::time(nullptr);
+    std::tm tm{};
+    gmtime_r(&t, &tm);
+    return rfc3339(tm);
+}
+
+manifest make_squashfs_manifest(digest layer_digest, std::size_t layer_size,
+                                std::string created) {
+    manifest m;
+    m.artifact_type = std::string{artifact_type_squashfs};
+    m.annotations[std::string{annotation_created}] = std::move(created);
+    m.layers.push_back(manifest_layer{
+        .media_type = std::string{media_type_layer_tar},
+        .digest = layer_digest,
+        .size = layer_size,
+        .annotations = {{std::string{annotation_title}, "store.squashfs"}}});
+    return m;
+}
 
 descriptor empty_config_descriptor() {
     return descriptor{

--- a/src/oci/manifest.h
+++ b/src/oci/manifest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <ctime>
 #include <map>
 #include <optional>
 #include <string>
@@ -92,6 +93,19 @@ struct manifest {
 // the same shape oras produces: schemaVersion, mediaType, artifactType, config,
 // layers, optional subject, annotations.
 std::string serialize_manifest(const manifest& m);
+
+// Build the single-layer image manifest used for every squashfs artifact uenv
+// pushes: artifact type application/x-squashfs, one layer titled
+// "store.squashfs", and an org.opencontainers.image.created annotation set to
+// `created` (an RFC3339 UTC timestamp, see rfc3339()/rfc3339_now() below).
+manifest make_squashfs_manifest(digest layer_digest, std::size_t layer_size,
+                                std::string created);
+
+// Format `tm` (UTC) as an RFC3339 timestamp, e.g. "2024-08-23T16:00:40Z" - the
+// format oras writes into org.opencontainers.image.created.
+std::string rfc3339(std::tm tm);
+// rfc3339() of the current UTC time.
+std::string rfc3339_now();
 
 // Parse an OCI image-manifest JSON document. Fails if the JSON is malformed or
 // a descriptor digest is invalid.

--- a/src/oci/push.cpp
+++ b/src/oci/push.cpp
@@ -1,4 +1,3 @@
-#include <ctime>
 #include <filesystem>
 #include <map>
 #include <optional>
@@ -25,17 +24,6 @@ namespace oci {
 namespace fs = std::filesystem;
 
 namespace {
-
-// current time as an RFC3339 UTC timestamp (e.g. 2024-08-23T16:00:40Z), the
-// format oras writes into org.opencontainers.image.created.
-std::string rfc3339_now() {
-    std::time_t t = std::time(nullptr);
-    std::tm tm{};
-    gmtime_r(&t, &tm);
-    char buf[32];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
-    return buf;
-}
 
 util::expected<digest, std::string> digest_of_file(const fs::path& p) {
     auto d = util::sha256_file(p);
@@ -222,7 +210,8 @@ void maintain_referrers_tag(client& c, const digest& subject,
 util::expected<digest, std::string>
 push_squashfs(client& c, const fs::path& squashfs, const reference& ref,
               std::optional<digest> layer_digest,
-              std::function<void(std::uint64_t, std::uint64_t)> progress) {
+              std::function<void(std::uint64_t, std::uint64_t)> progress,
+              std::optional<std::string> existing_manifest_body) {
     // hashing a multi-GB squashfs is expensive, so a caller that already has
     // the digest passes it in rather than paying for a second pass.
     if (!layer_digest) {
@@ -252,16 +241,10 @@ push_squashfs(client& c, const fs::path& squashfs, const reference& ref,
         return util::unexpected{ok.error().message};
     }
 
-    manifest m;
-    m.artifact_type = std::string{artifact_type_squashfs};
-    m.annotations[std::string{annotation_created}] = rfc3339_now();
-    m.layers.push_back(manifest_layer{
-        .media_type = std::string{media_type_layer_tar},
-        .digest = layer_digest.value(),
-        .size = size,
-        .annotations = {{std::string{annotation_title}, "store.squashfs"}}});
-
-    auto body = serialize_manifest(m);
+    auto body = existing_manifest_body
+                    ? std::move(*existing_manifest_body)
+                    : serialize_manifest(make_squashfs_manifest(
+                          layer_digest.value(), size, rfc3339_now()));
     if (auto ok = c.put_manifest(ref, body); !ok) {
         return util::unexpected{ok.error().message};
     }

--- a/src/oci/push.h
+++ b/src/oci/push.h
@@ -17,16 +17,20 @@ namespace oci {
 
 // Push a squashfs image as an OCI artifact (the native replacement for
 // `oras push --artifact-type application/x-squashfs`). Uploads the squashfs
-// blob and the empty config, builds an oras-compatible image manifest with the
-// layer titled "store.squashfs", and PUTs it under `ref` (a tag). Returns the
-// manifest digest — the canonical image id.
+// blob and the empty config, then PUTs an image manifest under `ref` (a tag).
+// Returns the manifest digest — the canonical image id.
 // `layer_digest` is the sha256 of `squashfs`; supply it when it has already
 // been computed, else it is calculated here, which reads the whole file.
+// `existing_manifest_body`, when set, is PUT verbatim instead of building a
+// fresh manifest — use this to push a manifest that was already minted (and
+// hashed) elsewhere, e.g. one persisted alongside a repository image, so the
+// pushed digest matches a digest already recorded locally.
 util::expected<digest, std::string>
 push_squashfs(client& c, const std::filesystem::path& squashfs,
               const reference& ref,
               std::optional<digest> layer_digest = std::nullopt,
-              std::function<void(std::uint64_t, std::uint64_t)> progress = {});
+              std::function<void(std::uint64_t, std::uint64_t)> progress = {},
+              std::optional<std::string> existing_manifest_body = std::nullopt);
 
 // Attach typed side-data to an existing image as an OCI referrer (the native
 // replacement for `oras attach`). `subject` identifies the target image (tag or

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -151,8 +151,10 @@ resolve_uenv_info(const uenv_record& record, const repository& store) {
     uenv_info info;
     info.record = record;
 
-    // set sqfs_path and digest
-    info.sqfs_path = fs::absolute(store.uenv_paths(record.sha).squashfs);
+    // set sqfs_path, manifest_path and digest
+    const auto paths = store.uenv_paths(record.sha);
+    info.sqfs_path = fs::absolute(paths.squashfs);
+    info.manifest_path = paths.manifest;
     if (!fs::exists(info.sqfs_path) || !fs::is_regular_file(info.sqfs_path)) {
         return unexpected(fmt::format(
             "the uenv image {} does not exist or is not a file. Run "

--- a/src/uenv/env.h
+++ b/src/uenv/env.h
@@ -45,6 +45,8 @@ struct uenv_info {
     std::optional<uenv_record> record;
     // path to meta directory if found
     std::optional<std::filesystem::path> meta_path;
+    // path to manifest.json if looked up from repo
+    std::optional<std::filesystem::path> manifest_path;
     // meta data loaded from meta_path/env.json
     std::optional<uenv::meta> meta;
     // the repo this image was found in (nullopt for squashfs file path inputs)

--- a/src/uenv/repository.cpp
+++ b/src/uenv/repository.cpp
@@ -803,7 +803,8 @@ repository::pathset repository_impl::uenv_paths(sha256 sha) const {
             .store_root = repo_store_root,
             .store = repo_store_root / lit,
             .meta = repo_store_root / lit / "meta",
-            .squashfs = repo_store_root / lit / "store.squashfs"};
+            .squashfs = repo_store_root / lit / "store.squashfs",
+            .manifest = repo_store_root / lit / "manifest.json"};
 }
 
 util::expected<void, std::string>

--- a/src/uenv/repository.h
+++ b/src/uenv/repository.h
@@ -176,6 +176,7 @@ struct repository {
         std::filesystem::path store;
         std::filesystem::path meta;
         std::filesystem::path squashfs;
+        std::filesystem::path manifest;
     };
 
     using enum repo_open_mode;

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <deque>
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <vector>
@@ -266,6 +267,22 @@ read_single_line_file(const std::filesystem::path& path) {
         }
     }
     return std::nullopt;
+}
+
+util::expected<std::string, std::string>
+read_file(const std::filesystem::path& path) {
+    std::ifstream file{path, std::ios::binary};
+    if (!file) {
+        return util::unexpected{
+            fmt::format("unable to open {}: {}", path.string(), std::strerror(errno))};
+    }
+    std::string content{std::istreambuf_iterator<char>{file},
+                        std::istreambuf_iterator<char>{}};
+    if (file.bad()) {
+        return util::unexpected{
+            fmt::format("unable to read {}: {}", path.string(), std::strerror(errno))};
+    }
+    return content;
 }
 
 bool is_child(const std::filesystem::path& child,

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -273,14 +273,14 @@ util::expected<std::string, std::string>
 read_file(const std::filesystem::path& path) {
     std::ifstream file{path, std::ios::binary};
     if (!file) {
-        return util::unexpected{
-            fmt::format("unable to open {}: {}", path.string(), std::strerror(errno))};
+        return util::unexpected{fmt::format(
+            "unable to open {}: {}", path.string(), std::strerror(errno))};
     }
     std::string content{std::istreambuf_iterator<char>{file},
                         std::istreambuf_iterator<char>{}};
     if (file.bad()) {
-        return util::unexpected{
-            fmt::format("unable to read {}: {}", path.string(), std::strerror(errno))};
+        return util::unexpected{fmt::format(
+            "unable to read {}: {}", path.string(), std::strerror(errno))};
     }
     return content;
 }

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -67,6 +67,10 @@ file_level file_access_level(const std::filesystem::path& path);
 std::optional<std::string>
 read_single_line_file(const std::filesystem::path& path);
 
+// read the full contents of a text file into a string.
+util::expected<std::string, std::string>
+read_file(const std::filesystem::path& path);
+
 // return if a path is inside a directory, i.e. direct or indirect child
 bool is_child(const std::filesystem::path& child,
               const std::filesystem::path& parent);

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -480,6 +480,29 @@ EOF
     refute_output --partial "warning"
     refute_output --partial "error"
 
+    # trying to add the same image should be a failure
+    run uenv --repo=$RP image add wombat/24:v1@arapiles%zen3 $SQFS_LIB/apptool/standalone/tool.squashfs
+    assert_failure
+    assert_output --partial "uenv already exists"
+
+    # trying to add the same image with a different label should be an error
+    run uenv --repo=$RP image add numbat/24:v1@arapiles%zen3 $SQFS_LIB/apptool/standalone/tool.squashfs
+    assert_failure
+    assert_output --partial "already in the repo"
+
+    # trying to add the same image via label should work
+    run uenv --repo=$RP image add numbat/24:v1@arapiles%zen3 wombat/24:v1@arapiles%zen3
+    assert_success
+    assert_output --partial "the uenv numbat/24:v1@arapiles%zen3"
+    assert_output --partial "was added to $RP"
+    refute_output --partial "warning"
+    refute_output --partial "error"
+
+    run uenv --repo=$RP image ls --no-header
+    assert_success
+    assert_output --partial "numbat/24:v1"
+    assert_output --partial "wombat/24:v1"
+
     # the manifest that identifies the image is persisted alongside it, and
     # the <hash> used to store/index the image is exactly the sha256 of that
     # manifest.
@@ -487,21 +510,6 @@ EOF
     wombat_manifest=$RP/images/$wombat_sha/manifest.json
     [ -f "$wombat_manifest" ]
     [ "$wombat_sha" = "$(sha256sum "$wombat_manifest" | cut -d' ' -f1)" ]
-
-    run uenv --repo=$RP image ls --no-header
-    assert_success
-    assert_output --partial "wombat/24:v1"
-
-    # trying to add the same image should be a failure
-    run uenv --repo=$RP image add wombat/24:v1@arapiles%zen3 $SQFS_LIB/apptool/standalone/tool.squashfs
-    assert_failure
-    assert_output --partial "uenv already exists"
-
-    # trying to add the same image with a different label should add the image and generate a warning
-    run uenv --repo=$RP image add numbat/24:v1@arapiles%zen3 $SQFS_LIB/apptool/standalone/tool.squashfs
-    assert_success
-    assert_output --partial "warning"
-    assert_output --partial "a uenv with the same sha"
 
     # the manifest hash is deterministic: adding identical squashfs content
     # under a different label reuses the same store/images/<hash> directory
@@ -516,7 +524,7 @@ EOF
     # assert that the number of lines in the output is 2: one for each uenv
     [ "${#lines[@]}" -eq "2" ]
 
-    # trying to add the same image with a different label should add the image and generate a warning
+    # add a different image with a different label
     run uenv --repo=$RP image add bilby/24:v1@arapiles%zen3 $SQFS_LIB/apptool/standalone/app42.squashfs
     assert_success
     refute_output --partial "warning"
@@ -535,7 +543,7 @@ EOF
     sqfs_file=$TMP/app43.squashfs
     cp $SQFS_LIB/apptool/standalone/app43.squashfs $sqfs_file
     [ -f  $sqfs_file ]
-    run uenv --repo=$RP image add --move quokka/24:v1@arapiles%zen3 $sqfs_file
+    run uenv -vv --repo=$RP image add --move quokka/24:v1@arapiles%zen3 $sqfs_file
     assert_success
     refute_output --partial "warning"
     refute_output --partial "error"

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -558,29 +558,18 @@ EOF
     assert_line --partial 'quokka/24:v1'
     [ "${#lines[@]}" -eq "4" ]
 
-    # trying to add the same image with a different label pointing to an SQFS file inside the repo should generate a warning
-    run uenv --repo=$RP image add wombat/24:replica@arapiles%zen3 $(uenv --repo=$RP image inspect --format='{sqfs}' wombat/24:v1@arapiles%zen3)
-    assert_success
-    assert_output --partial "warning"
-    assert_output --partial "a uenv with the same sha"
-
-    run uenv --repo=$RP image ls --no-header
-    assert_success
-    assert_line --partial 'wombat/24:v1'
-    assert_line --partial 'wombat/24:replica'
-    [ "${#lines[@]}" -eq "5" ]
-
-    # trying to add the same image by label
+    # adding a new label that aliases an image already in the repo (by label)
+    # is the sanctioned way to retag, and succeeds cleanly
     run uenv --repo=$RP image add numbat/24:replica@arapiles%zen3 numbat/24:v1
     assert_success
-    assert_output --partial "warning"
-    assert_output --partial "a uenv with the same sha"
+    refute_output --partial "warning"
+    refute_output --partial "error"
 
     run uenv --repo=$RP image ls --no-header
     assert_success
     assert_line --partial 'numbat/24:v1'
     assert_line --partial 'numbat/24:replica'
-    [ "${#lines[@]}" -eq "6" ]
+    [ "${#lines[@]}" -eq "5" ]
 
     # TODO:
     # - check a read-only repo
@@ -631,9 +620,10 @@ EOF
     assert_success
 
     # add uenv to a repo for us to try removing
-    # the wombat uenv have the same sha
+    # the wombat uenv have the same sha: the second label is added by aliasing
+    # the first, because adding the same squashfs a second time is an error
     uenv --repo=$UENV_REPO_PATH image add wombat/24:rc1@arapiles%zen3 $SQFS_LIB/apptool/standalone/tool.squashfs > /dev/null
-    uenv --repo=$UENV_REPO_PATH image add wombat/24:v1@arapiles%zen3  $SQFS_LIB/apptool/standalone/tool.squashfs > /dev/null
+    uenv --repo=$UENV_REPO_PATH image add wombat/24:v1@arapiles%zen3  wombat/24:rc1@arapiles%zen3 > /dev/null
     # the bilby images have unique sha
     uenv --repo=$UENV_REPO_PATH image add bilby/24:v1@arapiles%zen3   $SQFS_LIB/apptool/standalone/app42.squashfs > /dev/null
     uenv --repo=$UENV_REPO_PATH image add bilby/24:v2@arapiles%zen3   $SQFS_LIB/apptool/standalone/app43.squashfs > /dev/null
@@ -682,9 +672,10 @@ EOF
     assert_output ""
 
     # removing a one of multiple labels on the same sha removes the label but leaves the others untouched
-    # step 1: add another image with the same hash as the remaining image
-    run uenv --repo=$UENV_REPO_PATH image add wallaby/24:v2@arapiles%zen3   $SQFS_LIB/apptool/standalone/app43.squashfs > /dev/null
-    run uenv --repo=$UENV_REPO_PATH image add wallaby/24:v3@arapiles%zen3   $SQFS_LIB/apptool/standalone/app43.squashfs > /dev/null
+    # step 1: add more labels with the same hash as the remaining image
+    # (bilby/24:v2) by aliasing it, since re-adding the squashfs is an error
+    run uenv --repo=$UENV_REPO_PATH image add wallaby/24:v2@arapiles%zen3   bilby/24:v2@arapiles%zen3 > /dev/null
+    run uenv --repo=$UENV_REPO_PATH image add wallaby/24:v3@arapiles%zen3   bilby/24:v2@arapiles%zen3 > /dev/null
 
     pattern=wallaby/24:v2
     sha=$(uenv --repo=$UENV_REPO_PATH image inspect $pattern --format={sha256})

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -480,6 +480,14 @@ EOF
     refute_output --partial "warning"
     refute_output --partial "error"
 
+    # the manifest that identifies the image is persisted alongside it, and
+    # the <hash> used to store/index the image is exactly the sha256 of that
+    # manifest.
+    wombat_sha=$(uenv --repo=$RP image inspect --format='{sha256}' wombat/24:v1)
+    wombat_manifest=$RP/images/$wombat_sha/manifest.json
+    [ -f "$wombat_manifest" ]
+    [ "$wombat_sha" = "$(sha256sum "$wombat_manifest" | cut -d' ' -f1)" ]
+
     run uenv --repo=$RP image ls --no-header
     assert_success
     assert_output --partial "wombat/24:v1"
@@ -494,6 +502,12 @@ EOF
     assert_success
     assert_output --partial "warning"
     assert_output --partial "a uenv with the same sha"
+
+    # the manifest hash is deterministic: adding identical squashfs content
+    # under a different label reuses the same store/images/<hash> directory
+    # rather than storing a second copy.
+    numbat_sha=$(uenv --repo=$RP image inspect --format='{sha256}' numbat/24:v1)
+    [ "$wombat_sha" = "$numbat_sha" ]
 
     run uenv --repo=$RP image ls --no-header
     assert_success

--- a/test/integration/registry.bats
+++ b/test/integration/registry.bats
@@ -110,4 +110,58 @@ function teardown() {
     log "${output}"
     [ "${status}" -eq 0 ]
     assert_output --partial "app"
+
+    # the manifest fetched on pull is persisted alongside the image, keyed by
+    # its own digest.
+    [ -f "$RP/images/$digest/manifest.json" ]
+    [ "$digest" = "$(sha256sum "$RP/images/$digest/manifest.json" | cut -d' ' -f1)" ]
+}
+
+@test "uenv image push reuses a locally-added image's manifest.json" {
+    local sqfs=$SQFS_LIB/apptool/standalone/tool.squashfs
+    [ -f "$sqfs" ]
+
+    local RP=$TMP/repo
+    run uenv repo create "$RP"
+    assert_success
+
+    run uenv --repo "$RP" image add tool/1.0:v1@arapiles%zen3 "$sqfs"
+    assert_success
+
+    local local_sha
+    local_sha="$(uenv --repo "$RP" image inspect --format='{sha256}' tool/1.0:v1@arapiles%zen3)"
+    [ -f "$RP/images/$local_sha/manifest.json" ]
+
+    # push by label (not by file path): this resolves the source against the
+    # local repo and must reuse its manifest.json verbatim, rather than
+    # minting a fresh one.
+    run uenv --repo "$RP" image push tool/1.0:v1@arapiles%zen3 "deploy::apptag/1.0:v1@arapiles%zen3"
+    assert_success
+
+    local repo="${REG_PREFIX}/deploy/arapiles/zen3/apptag/1.0"
+    local registry_digest
+    registry_digest="$(registry_ctl digest "$REG_PORT" "$repo" v1)"
+    [ -n "$registry_digest" ]
+
+    # the digest the registry stores the image under must be exactly the hash
+    # it is already stored under locally - proof the manifest was reused, not
+    # re-minted.
+    [ "$registry_digest" = "$local_sha" ]
+
+    # pulling it back into a fresh repo must also persist manifest.json,
+    # byte-identical to the one minted by `image add`.
+    listing_mock add "$LISTING_FILE" \
+        --path "deploy/arapiles/zen3/apptag/1.0/v1" --sha "$registry_digest" \
+        --size "$(stat -c%s "$sqfs")"
+
+    local RP2=$TMP/repo2
+    run uenv repo create "$RP2"
+    assert_success
+
+    run uenv --repo "$RP2" image pull "deploy::apptag/1.0:v1@arapiles%zen3"
+    assert_success
+
+    [ -f "$RP2/images/$registry_digest/manifest.json" ]
+    diff "$RP/images/$local_sha/manifest.json" \
+         "$RP2/images/$registry_digest/manifest.json"
 }

--- a/test/unit/oci_manifest.cpp
+++ b/test/unit/oci_manifest.cpp
@@ -1,3 +1,5 @@
+#include <ctime>
+
 #include <catch2/catch_all.hpp>
 
 #include <oci/digest.h>
@@ -102,6 +104,46 @@ TEST_CASE("serialize meta referrer manifest is oras-identical",
     REQUIRE(digest_of(body) ==
             "sha256:"
             "f7f04f3b2cf562336c73542f0c53503c3b853ac459f081878843f878955cf267");
+}
+
+// make_squashfs_manifest is the single place both `uenv image add` (minting a
+// manifest for a newly-added local squashfs) and oci::push_squashfs (minting
+// one for a fresh push) build a squashfs manifest, so it must reproduce
+// exactly the same bytes as the hand-built manifest above.
+TEST_CASE("make_squashfs_manifest matches a hand-built manifest",
+          "[oci][manifest]") {
+    auto m = make_squashfs_manifest(sha_digest(image_layer_hex), 4046512128,
+                                    "2024-08-23T16:00:40Z");
+
+    const std::string expected =
+        R"({"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/x-squashfs","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"sha256:b563b338a3797eb908b1f60a3b710b7021599aaac61d02f11b273bd2ff0986d4","size":4046512128,"annotations":{"org.opencontainers.image.title":"store.squashfs"}}],"annotations":{"org.opencontainers.image.created":"2024-08-23T16:00:40Z"}})";
+
+    REQUIRE(serialize_manifest(m) == expected);
+}
+
+TEST_CASE("rfc3339 formats a std::tm as a UTC RFC3339 timestamp",
+          "[oci][manifest]") {
+    std::tm tm{};
+    tm.tm_year = 2024 - 1900;
+    tm.tm_mon = 8 - 1;
+    tm.tm_mday = 23;
+    tm.tm_hour = 16;
+    tm.tm_min = 0;
+    tm.tm_sec = 40;
+    REQUIRE(rfc3339(tm) == "2024-08-23T16:00:40Z");
+}
+
+TEST_CASE("rfc3339_now looks like an RFC3339 UTC timestamp",
+          "[oci][manifest]") {
+    auto s = rfc3339_now();
+    // "YYYY-MM-DDTHH:MM:SSZ"
+    REQUIRE(s.size() == 20);
+    REQUIRE(s[4] == '-');
+    REQUIRE(s[7] == '-');
+    REQUIRE(s[10] == 'T');
+    REQUIRE(s[13] == ':');
+    REQUIRE(s[16] == ':');
+    REQUIRE(s[19] == 'Z');
 }
 
 // parse_manifest is the read counterpart: parsing a serialized manifest must

--- a/test/unit/repository.cpp
+++ b/test/unit/repository.cpp
@@ -263,6 +263,22 @@ TEST_CASE("create disk repo", "[repository]") {
     }
 }
 
+TEST_CASE("uenv_paths includes the manifest path", "[repository]") {
+    auto repo_dir = util::make_temp_dir().value();
+    auto R = uenv::create_repository(repo_dir);
+    REQUIRE(R);
+
+    const auto sha = msha('a');
+    const auto paths = R->uenv_paths(sha);
+
+    REQUIRE(paths.store == paths.store_root / sha.string());
+    REQUIRE(paths.manifest == paths.store / "manifest.json");
+    // manifest.json is a sibling of store.squashfs and meta/, inside the same
+    // per-image store directory.
+    REQUIRE(paths.manifest.parent_path() == paths.squashfs.parent_path());
+    REQUIRE(paths.manifest.parent_path() == paths.meta.parent_path());
+}
+
 // helper: make a repo_description with default priority
 static uenv::repo_description
 rd(std::string name, std::string path,


### PR DESCRIPTION
Store manifests in the repository, alongside squashfs images.

Now that uenv has it's own OCI implementation, a manifest can be created when a uenv is added to a repository using `uenv image add`. then use that manifest when the image is pushed to a registry.

With this, images can be added to a repository, and copied between registries and repositories while maintaining the same hash (always the hash of the manifest)