### PR TITLE
add check instead of silently discard a uenv in case of same name

### DIFF
--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -414,6 +414,11 @@ concretise_env(const std::vector<resolved_uenv>& input_uenvs,
         const bool has_meta = (bool)info.meta;
         const bool has_record = (bool)info.record;
 
+        if (uenvs.contains(name)) {
+            return unexpected(fmt::format(
+                "trying to mount multiple uenvs with same name '{}'", name));
+        }
+
         uenvs[name] = concrete_uenv{
             .name = name,
             .label = has_record ? fmt::format("{}", info.record.value())


### PR DESCRIPTION
It is a bit of an edge case, because I was trying to load two versions of the same uenv in two different mountpoints for comparison. But I was getting loaded just one of them.

The verbose log shows that both were getting considered (metadata, ...), but just the last one made it to the actual mount phase. Actually, there are checks that we don't re-use mountpoints, but there is no guard in case uenvs have the exact same name.

Again, it's an edge case, but IMHO it would be better to be explicit about what's going on (and fail or at least raise a warning) instead of having it working but not doing what the cli asked (legit or not).