### PR TITLE
Validate manifest digests

### DIFF
--- a/src/oci/client.cpp
+++ b/src/oci/client.cpp
@@ -349,6 +349,15 @@ util::expected<void, client_error> client_impl::get_blob_to_file(
 
 util::expected<manifest_response, client_error>
 client_impl::get_manifest(const reference& ref) {
+    // a manifest whose digest cannot be computed cannot be verified, so it is
+    // never fetched: an unsupported algorithm is an error rather than a
+    // response that silently skips the check below.
+    if (ref.is_digest() && ref.as_digest().algorithm() != "sha256") {
+        return util::unexpected{client_error{fmt::format(
+            "unable to verify manifest {}: unsupported digest algorithm '{}'",
+            ref.string(), ref.as_digest().algorithm())}};
+    }
+
     util::curl::request req;
     req.url =
         registry_url_.resolve(detail::manifest_path(repository_, ref.string()))
@@ -367,15 +376,38 @@ client_impl::get_manifest(const reference& ref) {
                         util::curl::http_message(resp->status)),
             resp->status}};
     }
-    manifest_response m;
-    m.body = std::move(resp->body);
+    // A manifest's identity is the hash of its bytes, so it is computed here
+    // and never taken from the Docker-Content-Digest header, which is only the
+    // registry's assertion about its own response. Everything downstream hangs
+    // off this: the layer digests that get_blob_to_file verifies against are
+    // read out of this body, so a manifest taken on trust makes every check
+    // below it self-referential.
+    const auto computed = digest::sha256(util::sha256_string(resp->body));
+
+    // A digest reference is a pin — uenv identifies an image by its manifest
+    // digest — so bytes that hash to anything else are content the caller did
+    // not ask for, whatever the registry says about them.
+    if (ref.is_digest() && ref.as_digest() != computed) {
+        return util::unexpected{client_error{
+            fmt::format("manifest digest mismatch: requested {}, but the "
+                        "registry returned content with digest {}",
+                        ref.as_digest().string(), computed.string())}};
+    }
     if (auto header = resp->headers.get("docker-content-digest")) {
-        if (auto d = digest::parse(*header)) {
-            m.digest = *d;
+        if (*header != computed.string()) {
+            spdlog::warn("the registry reported manifest {} as {}, which does "
+                         "not match the content it returned ({})",
+                         ref.string(), *header, computed.string());
         }
     }
-    m.media_type = resp->headers.get("content-type").value_or("");
-    return m;
+    spdlog::debug("oci::get_manifest {} has digest {}, computed over the "
+                  "response body",
+                  ref.string(), computed.string());
+
+    return manifest_response{
+        .body = std::move(resp->body),
+        .digest = computed,
+        .media_type = resp->headers.get("content-type").value_or("")};
 }
 
 util::expected<std::vector<std::string>, client_error>

--- a/src/oci/push.cpp
+++ b/src/oci/push.cpp
@@ -277,12 +277,11 @@ util::expected<descriptor, std::string> attach(client& c,
         return util::unexpected{fmt::format("unable to resolve subject {}: {}",
                                             subject.string(), subj.error())};
     }
-    descriptor subject_desc{
-        .media_type = subj->media_type.empty()
-                          ? std::string{media_type_manifest}
-                          : subj->media_type,
-        .digest = subj->digest ? *subj->digest : digest_of_string(subj->body),
-        .size = subj->body.size()};
+    descriptor subject_desc{.media_type = subj->media_type.empty()
+                                              ? std::string{media_type_manifest}
+                                              : subj->media_type,
+                            .digest = subj->digest,
+                            .size = subj->body.size()};
 
     // package the payload.
     util::expected<packaged_layer, std::string> packaged =
@@ -361,7 +360,7 @@ copy_image(const util::url& registry_base, const std::string& src_repo,
             fmt::format("unable to fetch source manifest {}: {}",
                         src_manifest.string(), mr.error())};
     }
-    const digest manifest_digest = mr->digest.value_or(src_manifest);
+    const digest manifest_digest = mr->digest;
     const std::string_view manifest_media =
         mr->media_type.empty() ? media_type_manifest
                                : std::string_view{mr->media_type};

--- a/src/oci/readme.md
+++ b/src/oci/readme.md
@@ -236,7 +236,7 @@ std::string repository_path(prefix, nspace, system, uarch, name, version);
 
 struct manifest_response {
     std::string body;
-    std::optional<oci::digest> digest;   // Docker-Content-Digest, when sound
+    oci::digest digest;                  // computed over body, never a header
     std::string media_type;
 };
 ```
@@ -247,8 +247,10 @@ It cannot fail: the url was already parsed when the configuration was read (see
 "URLs" below). `repository_path` then builds the repository name from a uenv
 label, matching the address `oras` used. Both are pure functions.
 
-`manifest_response` keeps the raw bytes alongside the registry's reported digest
-because the bytes are what you must re-digest locally to confirm identity.
+`manifest_response` keeps the raw bytes alongside their digest, which
+`get_manifest` computes over those bytes. The `Docker-Content-Digest` header is
+never used for it: the header is the registry's assertion about its own
+response, so trusting it would let a registry name content it did not send.
 
 ### `client.h` — the registry connection
 
@@ -280,7 +282,7 @@ Read operations:
 | --- | --- |
 | `blob_exists(digest)` | HEAD a blob; 200 → true, 404 → false |
 | `get_blob_to_file(digest, path, progress, should_abort)` | stream a blob to disk, following redirects to backing storage |
-| `get_manifest(reference)` | fetch a manifest by tag or digest |
+| `get_manifest(reference)` | fetch a manifest by tag or digest, verifying the bytes against the digest |
 | `list_tags()` | list the repository's tags |
 | `referrers(digest)` | list artifacts attached to a manifest |
 
@@ -546,9 +548,17 @@ if (!manifest) { /* report manifest.error() */ }
 ```
 
 Fetching and parsing are separate steps because the raw bytes and the parsed
-model serve different purposes: the bytes are what you re-digest to confirm
-identity, and the parsed manifest is what tells you which layers to fetch. The
-manifest is fetched once and reused by both pulls below.
+model serve different purposes: the bytes carry the image's identity, and the
+parsed manifest is what tells you which layers to fetch. The manifest is fetched
+once and reused by both pulls below.
+
+A digest reference is a **pin**, and `get_manifest` enforces it: it hashes the
+response body and fails unless it matches the requested digest, so `response`
+either holds the bytes that were asked for or is an error. This is the trust
+anchor of the whole pull — the layer digests that `get_blob_to_file` verifies
+against are read out of this body, so a manifest taken on trust would make
+every check below it self-referential. `response->digest` is that computed
+digest.
 
 Metadata first, since it is small and its absence may be a reason to stop:
 

--- a/src/oci/types.h
+++ b/src/oci/types.h
@@ -59,13 +59,17 @@ std::string repository_path(std::string_view prefix, std::string_view nspace,
                             std::string_view system, std::string_view uarch,
                             std::string_view name, std::string_view version);
 
-// The result of fetching a manifest: the raw bytes plus the registry-reported
-// digest and media type. The bytes are what must be re-digested locally to
-// confirm identity.
+// The result of fetching a manifest: the raw bytes plus their locally computed
+// digest and the media type.
 struct manifest_response {
     std::string body;
-    // value of the Docker-Content-Digest header, when present and well-formed.
-    std::optional<oci::digest> digest;
+    // the digest of `body`, computed locally by client::get_manifest. never
+    // the Docker-Content-Digest header: that is the registry's assertion
+    // about its own response, so taking it as the manifest's identity would
+    // let a registry name content it did not send. a manifest fetched by
+    // digest has already been checked against the requested digest, so this
+    // is equal to it.
+    oci::digest digest;
     std::string media_type;
 };
 

--- a/test/unit/oci_registry.cpp
+++ b/test/unit/oci_registry.cpp
@@ -132,6 +132,56 @@ util::url registry_url() {
     return *util::parse_url(registry_base());
 }
 
+// A lying registry: a plain static file server whose directory tree mimics the
+// distribution API, so a manifest body can be served at a path naming a digest
+// the body does not hash to. A content-addressed registry such as zot cannot
+// produce that response, which is the point — this stands in for a compromised
+// or malicious registry. Needs only python3; the cases SKIP without it.
+struct static_registry {
+    std::optional<util::subprocess> proc;
+    std::string base; // http://127.0.0.1:PORT, empty when unavailable
+    std::filesystem::path root;
+
+    static_registry() {
+        root = util::make_temp_dir().value();
+        // GET /v2/ must answer 200 for the client to bind anonymously; a
+        // directory listing does.
+        std::filesystem::create_directories(root / "v2");
+        const int port = free_port();
+        auto p =
+            util::run({"python3", "-m", "http.server", std::to_string(port),
+                       "--bind", "127.0.0.1", "--directory", root.string()});
+        if (!p) {
+            return; // no python3 -> tests skip
+        }
+        const auto url = fmt::format("http://127.0.0.1:{}", port);
+        for (int i = 0; i < 100; ++i) { // up to ~20s
+            if (p->finished()) {
+                return;
+            }
+            if (ready(url)) {
+                proc = std::move(*p);
+                base = url;
+                return;
+            }
+            ::usleep(200 * 1000);
+        }
+        p->kill();
+    }
+
+    ~static_registry() {
+        if (proc) {
+            proc->kill();
+        }
+    }
+};
+
+// the shared static server, or empty base when one could not be started.
+const static_registry& lying_registry() {
+    static static_registry instance;
+    return instance;
+}
+
 void write_file(const std::filesystem::path& path, std::string_view content) {
     std::ofstream f{path, std::ios::binary};
     f << content;
@@ -169,9 +219,16 @@ TEST_CASE("oci registry push/pull round-trip", "[registry]") {
     REQUIRE(resp.has_value());
     const auto local = oci::digest::sha256(util::sha256_string(resp->body));
     REQUIRE(local == *pushed);
-    if (resp->digest) {
-        REQUIRE(*resp->digest == *pushed);
-    }
+    // get_manifest computes the digest itself rather than reading the
+    // registry's Docker-Content-Digest header.
+    REQUIRE(resp->digest == *pushed);
+
+    // fetching by that digest is a pin: the same bytes come back, and the
+    // response reports the digest that was asked for.
+    auto by_digest = c->get_manifest(oci::reference::digest(*pushed));
+    REQUIRE(by_digest.has_value());
+    REQUIRE(by_digest->body == resp->body);
+    REQUIRE(by_digest->digest == *pushed);
 
     // pull the layer back; pull_squashfs self-verifies its digest internally.
     auto image = oci::parse_manifest(resp->body);
@@ -378,4 +435,55 @@ TEST_CASE("oci registry push_squashfs with a precomputed digest",
     const auto blob = dir / "pulled.squashfs";
     REQUIRE(c->get_blob_to_file(layer, blob).has_value());
     REQUIRE(read_file(blob) == payload);
+}
+
+// The registry is the one thing a pull cannot take on trust: every layer
+// digest that get_blob_to_file verifies against is read out of the manifest,
+// so a manifest accepted without checking makes every check below it
+// self-referential.
+TEST_CASE("oci registry a manifest is rejected unless it hashes to the "
+          "requested digest",
+          "[registry]") {
+    const auto& reg = lying_registry();
+    if (reg.base.empty()) {
+        SKIP("no python3 available to serve the static registry");
+    }
+
+    const std::string repo = "test/lying/1.0";
+    const std::string body = R"({"schemaVersion":2,"layers":[]})";
+    const auto dir =
+        reg.root / "v2" / std::filesystem::path{repo} / "manifests";
+    REQUIRE(util::ensure_directory(dir).has_value());
+
+    auto c = oci::client::create(*util::parse_url(reg.base), repo);
+    REQUIRE(c.has_value());
+
+    // the caller pins a digest; the registry answers with different bytes.
+    const auto pinned =
+        oci::digest::sha256(util::sha256_string("the manifest that was asked "
+                                                "for"));
+    write_file(dir / pinned.string(), body);
+    auto swapped = c->get_manifest(oci::reference::digest(pinned));
+    REQUIRE(!swapped.has_value());
+    REQUIRE(swapped.error().message.find("digest mismatch") !=
+            std::string::npos);
+
+    // the same bytes under their own digest are accepted, and the response
+    // carries the locally computed digest.
+    const auto honest = oci::digest::sha256(util::sha256_string(body));
+    write_file(dir / honest.string(), body);
+    auto ok = c->get_manifest(oci::reference::digest(honest));
+    REQUIRE(ok.has_value());
+    REQUIRE(ok->body == body);
+    REQUIRE(ok->digest == honest);
+
+    // a digest the client cannot compute is a hard error, not an unverified
+    // pass-through.
+    const auto sha512 = oci::digest::parse("sha512:" + std::string(128, 'a'));
+    REQUIRE(sha512.has_value());
+    write_file(dir / sha512->string(), body);
+    auto unsupported = c->get_manifest(oci::reference::digest(*sha512));
+    REQUIRE(!unsupported.has_value());
+    REQUIRE(unsupported.error().message.find("unsupported digest algorithm") !=
+            std::string::npos);
 }


### PR DESCRIPTION
validate digests of manifests against what the registry provides to protect against malicious registries